### PR TITLE
fix timouts in send_can_cfc0. 

### DIFF
--- a/elm.py
+++ b/elm.py
@@ -924,6 +924,9 @@ class ELM:
         Fc = 0  # Current frame
         Fn = len(raw_command)  # Number of frames
 
+        if Fn > 1 or len(raw_command[0])>15: # set elm timeout to 300ms for first response
+          self.send_raw('ATST4B')
+
         while Fc < Fn:
 
             # enable responses
@@ -933,10 +936,15 @@ class ELM:
 
             tb = time.time()  # time of sending (ff)
 
-            if len(raw_command[Fc]) == 16:
-                frsp = self.send_raw(raw_command[Fc])  # we'll get only 1 frame: fc, ff or sf
+            if Fn > 1 and Fc == (Fn-1):  # set elm timeout to maximum for last response on long command
+                self.send_raw('ATSTFF')
+                self.send_raw('ATAT1')
+
+            if (Fc == 0 or Fc == (Fn-1)) and len(raw_command[Fc])<16:  #first or last frame in command and len<16 (bug in ELM)
+                frsp = self.send_raw (raw_command[Fc] + '1')  # we'll get only 1 frame: nr, fc, ff or sf
             else:
-                frsp = self.send_raw(raw_command[Fc] + '1')  # we'll get only 1 frame: fc, ff or sf
+                frsp = self.send_raw (raw_command[Fc])
+
             Fc = Fc + 1
 
             # analyse response


### PR DESCRIPTION
Hi
This fix works with multi-frame commands. It set 300ms timeout before sending first frame for waiting FlowControl  and maximum timeout 1000ms before sending last frame for waiting final result of this command. I know that this function not working usually but it may be enabled in option.py by changing opt_cfc0 to True.

