### PR TITLE
Fix UTF8 error with PyQt5

### DIFF
--- a/ddt4all.py
+++ b/ddt4all.py
@@ -864,7 +864,7 @@ class Main_widget(widgets.QMainWindow):
         if qt5:
             filename = str(filename_tuple[0])
         else:
-            filename = unicode(filename_tuple, encoding="UTF-8")
+            filename = utf8(filename_tuple)
         if filename == '':
             return
 
@@ -1206,7 +1206,7 @@ class portChooser(widgets.QDialog):
             if not currentitem:
                 self.logview.hide()
                 return
-            portinfo = unicode(currentitem.text().toUtf8(), encoding="utf-8")
+            portinfo = utf8(currentitem.text())
             port = self.ports[portinfo][0]
         speed = int(self.speedcombo.currentText())
         res = elm.elm_checker(port, speed, self.logview, core.QCoreApplication)


### PR DESCRIPTION
OS version:         macOs Mojave 10.14.4
Python version:  2.7.16
Qt version           5.13.0

With fix:
- ELM benchmark works

Without fix:
This error occurs:
```
Traceback (most recent call last):
File "ddt4all.py", line 1209, in check_elm
  portinfo = unicode(currentitem.text().toUtf8(), encoding="utf-8")
  AttributeError: 'unicode' object has no attribute 'toUtf8'
  fish: 'python ddt4all.py' terminated by signal SIGABRT (Abort)
```