### PR TITLE
fix for reading empty vin

### DIFF
--- a/ecu.py
+++ b/ecu.py
@@ -664,7 +664,7 @@ class Ecu_data:
             return None
 
         if self.bytesascii:
-            return bytes.fromhex(value).decode('utf-8')
+            return bytes.fromhex(value).decode('utf-8',errors="ignore")
 
         # I think we want Hex format for non scaled values
         if not self.scaled:


### PR DESCRIPTION
When VIN is empty, it contains 0x00 or 0xFF which can't be converted to ascii by decode function.