### PR TITLE
Fix for ELM writing timeout

### DIFF
--- a/elm.py
+++ b/elm.py
@@ -801,7 +801,7 @@ class ELM:
         val = value // 4
         if val > 255:
             val = 255
-        val = hex(val)[2:].upper()
+        val = hex(val)[2:].upper().zfill(2)
         self.cmd("AT ST %s" % val)
 
     def send_cmd(self, command):

--- a/elm.py
+++ b/elm.py
@@ -961,8 +961,11 @@ class ELM:
         Fn = len(raw_command)  # Number of frames
 
         if Fn > 1 or len(raw_command[0]) > 15:
-            # set elm timeout to 300ms for first response
-            self.send_raw('AT ST 4B')
+            if options.cantimeout > 0:
+                self.set_can_timeout( options.cantimeout )
+            else:
+                # set elm timeout to 300ms for first response
+                self.send_raw('AT ST 4B')
 
         while Fc < Fn:
             # enable responses


### PR DESCRIPTION
This fix allows to use the timeout defined on a main screen for sending long commands.
For sending long command (more than 1000 bytes) the timeout should be small enough for writing complete command in 5 seconds. This fix allows to use as small as 4 ms values.
But this have a side effect. Too small timeout may prevent reading data from the ECU, so for writing data to ECU it should be  as small as 1-10 ms but for reading data it should be 100-200ms