### PR TITLE
fix: ValueError: invalid literal for int() with base 2: 0bb1000000000…

### DIFF
--- a/ecu.py
+++ b/ecu.py
@@ -640,7 +640,9 @@ class Ecu_data:
                 requestasbin[i + start_bit] = valueasbin[i]
 
         requestasbin = "".join(requestasbin)
-        valueasint = int("0b" + requestasbin, 2)
+        # valueasint = int("0b" + requestasbin, 2)
+        requestasbin = "0b" + requestasbin.lstrip("b")
+        valueasint = int(requestasbin, 2)
         valueashex = hex(valueasint)[2:].replace("L", "").zfill(numreqbytes * 2).upper()
 
         for i in range(numreqbytes):

--- a/ecu.py
+++ b/ecu.py
@@ -640,7 +640,6 @@ class Ecu_data:
                 requestasbin[i + start_bit] = valueasbin[i]
 
         requestasbin = "".join(requestasbin)
-        # valueasint = int("0b" + requestasbin, 2)
         requestasbin = "0b" + requestasbin.lstrip("b")
         valueasint = int(requestasbin, 2)
         valueashex = hex(valueasint)[2:].replace("L", "").zfill(numreqbytes * 2).upper()


### PR DESCRIPTION
I don't know how/why but it seems a conversion bug, an extra b is added : 

'0bb1000000000000000000000000000000'

it should be
'0b1000000000000000000000000000000'


  File "/Users/jodaille/ddt4allwithplugin/ecu.py", line 300, in build_data_stream
    data.setValue(v, data_stream, datatitem, self.ecu_file.endianness)
  File "/Users/jodaille/ddt4allwithplugin/ecu.py", line 643, in setValue
    valueasint = int("0b" + requestasbin, 2)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: invalid literal for int() with base 2: '0bb1000000000000000000000000000000'

You can test in manual request : 

<img width="1005" alt="Capture d’écran 2025-03-12 à 16 03 11" src="https://github.com/user-attachments/assets/321dec69-b09d-4b64-a856-17a752a379b1" />
