### PR TITLE
Fix WiFi ELM initialization deadlock

### DIFF
--- a/src/ddt4all/core/elm/elm.py
+++ b/src/ddt4all/core/elm/elm.py
@@ -417,7 +417,14 @@ class ELM:
                 hasattr(self.port, 'expect') and 
                 hasattr(self.port, 'connectionStatus') and 
                 self.port.connectionStatus):
-                self.port.expect(">")
+                if getattr(self.port, "portType", 0) == 1:
+                    try:
+                        self.port.write(b"\r")
+                        self.port.expect(">", time_out=0.5)
+                    except Exception:
+                        pass
+                else:
+                    self.port.expect(">", time_out=1)
                 res = self.send_raw("ATZ")
             else:
                 options.elm_failed = True

--- a/src/ddt4all/core/elm/port.py
+++ b/src/ddt4all/core/elm/port.py
@@ -1,6 +1,7 @@
 import platform
 import re
 import serial
+import select
 import socket
 import sys
 import threading
@@ -402,29 +403,34 @@ class Port:
         # return ''
 
     def expect(self, pattern, time_out=1):
-        tb = time.time()  # start time
+        tb = time.time()
         self.buff = ""
-
+        deadline = tb + time_out
+    
         while True:
             if not options.simulation_mode:
+                if self.portType == 1 and self.hdr is not None:
+                    remaining = deadline - time.time()
+                    if remaining <= 0:
+                        return self.buff + _("TIMEOUT")
+                    rlist, _, _ = select.select([self.hdr], [], [], min(0.05, remaining))
+                    if not rlist:
+                        continue
                 byte = self.read()
             else:
                 byte = '>'
-
+    
             if byte == '\r':
                 byte = '\n'
+    
             if byte:
                 self.buff += byte
-            tc = time.time()
+    
             if pattern in self.buff:
                 return self.buff
-            if (tc - tb) > time_out:
+    
+            if time.time() > deadline:
                 return self.buff + _("TIMEOUT")
-
-        # self.close()
-        # self.connectionStatus = False
-        # return ''
-
     def check_elm(self):
 
         timeout = 2


### PR DESCRIPTION
Summary
Fixes a startup deadlock with some WiFi ELM327 adapters that remain silent until receiving a carriage return.

Problem
DDT4ALL waits for the initial '>' prompt before sending ATZ. Some WiFi ELM adapters do not emit this prompt until they receive '\r', causing initialization to hang indefinitely when the socket is blocking.

Fix
- Send '\r' before the initial prompt wait for WiFi adapters
- Ensure expect() does not block indefinitely on WiFi sockets by using a bounded readiness check

Result
WiFi ELM adapters that previously required manual wake-up (e.g. pressing Enter via netcat) now initialize correctly in DDT4ALL.

Reproduction (before fix)
1. Connect to WiFi ELM327
2. Start DDT4ALL
3. Click "Connected mode"
4. Initialization hangs until external input is sent to the adapter

After fix
Initialization completes without external interaction.

Tested
- WiFi ELM327 (192.168.0.10:35000)
- Verified ATZ / ATI responses
- Confirmed DDT4ALL connects without manual intervention