### PR TITLE
fix(ecu): preserve exact project filters

### DIFF
--- a/src/ddt4all/core/ecu/ecu_database.py
+++ b/src/ddt4all/core/ecu/ecu_database.py
@@ -39,7 +39,7 @@ class EcuDatabase:
         jsonecu_files = glob.glob("./json/*.json.targets")
         for jsonecu_file in jsonecu_files:
             self.numecu += 1
-            json_file = open(jsonecu_file, "r")
+            json_file = open(jsonecu_file)
             json_data = json_file.read()
             json_file.close()
             ecus_dict = json.loads(json_data)
@@ -69,16 +69,15 @@ class EcuDatabase:
                     print(_("Adding group "), addr, ecu_dict['group'])
                     self.addr_group_mapping[str(addr)] = ecu_dict['group']
 
-                ecu_ident = EcuIdent(diagversion, ecu_dict['supplier_code'],
-                                      ecu_dict['soft_version'], ecu_dict['version'],
-                                      name, ecu_dict['group'], href, ecu_dict['protocol'],
-                                      ecu_dict['projects'], addr)
+                ecu_ident = EcuIdent(
+                    diagversion, ecu_dict['supplier_code'],
+                    ecu_dict['soft_version'], ecu_dict['version'],
+                    name, ecu_dict['group'], href, ecu_dict['protocol'],
+                    ecu_dict['projects'], addr,
+                )
 
                 for proj in ecu_dict['projects']:
-                    projname = proj[0:3].upper()
-                    if projname not in self.vehiclemap:
-                        self.vehiclemap[projname] = []
-                    self.vehiclemap[projname].append((ecu_dict['protocol'], addr))
+                    self.addVehicleMapEntry(proj, ecu_dict['protocol'], addr)
 
                 self.targets.append(ecu_ident)
 
@@ -108,23 +107,24 @@ class EcuDatabase:
                     self.addr_group_mapping[ecuaddress] = targetv['group']
 
                 if len(targetv['autoidents']) == 0:
-                    ecu_ident = EcuIdent("", "", "", "", ecuname, ecugroup, href, ecuprotocol,
-                                          ecuprojects, ecuaddress, True)
+                    ecu_ident = EcuIdent(
+                        "", "", "", "", ecuname, ecugroup, href, ecuprotocol,
+                        ecuprojects, ecuaddress, True,
+                    )
                     self.targets.append(ecu_ident)
                 else:
                     for target in targetv['autoidents']:
-                        ecu_ident = EcuIdent(target['diagnostic_version'], target['supplier_code'],
-                                              target['soft_version'], target['version'],
-                                              ecuname, ecugroup, href, ecuprotocol,
-                                              ecuprojects, ecuaddress, True)
+                        ecu_ident = EcuIdent(
+                            target['diagnostic_version'], target['supplier_code'],
+                            target['soft_version'], target['version'],
+                            ecuname, ecugroup, href, ecuprotocol,
+                            ecuprojects, ecuaddress, True,
+                        )
 
                         self.targets.append(ecu_ident)
 
                 for proj in ecuprojects:
-                    projname = proj[0:3].upper()
-                    if projname not in self.vehiclemap:
-                        self.vehiclemap[projname] = []
-                    self.vehiclemap[projname].append((ecuprotocol, ecuaddress))
+                    self.addVehicleMapEntry(proj, ecuprotocol, ecuaddress)
 
                 self.targets.append(ecu_ident)
 
@@ -169,27 +169,43 @@ class EcuDatabase:
                     projects = []
                     if projectselems:
                         for c in projectselems[0].childNodes:
-                            projects.append(c.nodeName)
+                            if c.nodeType == c.ELEMENT_NODE:
+                                projects.append(c.nodeName)
                     for autoident in autoidents:
                         if len(autoident.getElementsByTagName("AutoIdent")) == 0:
-                            ecu_ident = EcuIdent("00", "??????", "0000", "0000", name, group, href, protocol,
-                                                  projects, address)
+                            ecu_ident = EcuIdent(
+                                "00", "??????", "0000", "0000", name, group,
+                                href, protocol, projects, address,
+                            )
                             self.targets.append(ecu_ident)
                         for ai in autoident.getElementsByTagName("AutoIdent"):
                             diagversion = ai.getAttribute("DiagVersion")
                             supplier = ai.getAttribute("Supplier")
                             soft = ai.getAttribute("Soft")
                             version = ai.getAttribute("Version")
-                            ecu_ident = EcuIdent(diagversion, supplier, soft, version, name, group, href, protocol,
-                                                  projects, address)
+                            ecu_ident = EcuIdent(
+                                diagversion, supplier, soft, version, name,
+                                group, href, protocol, projects, address,
+                            )
                             self.targets.append(ecu_ident)
 
                     if projectselems:
                         for project in projectselems[0].childNodes:
-                            projname = project.nodeName[0:3].upper()
-                            if projname not in self.vehiclemap:
-                                self.vehiclemap[projname] = []
-                            self.vehiclemap[projname].append((ecu_ident.protocol, address))
+                            if project.nodeType == project.ELEMENT_NODE:
+                                self.addVehicleMapEntry(
+                                    project.nodeName, ecu_ident.protocol, address
+                                )
+
+    def addVehicleMapEntry(self, project, protocol, addr):
+        project = str(project).upper()
+        if not project:
+            return
+
+        entry = (protocol, addr)
+        if project not in self.vehiclemap:
+            self.vehiclemap[project] = []
+        if entry not in self.vehiclemap[project]:
+            self.vehiclemap[project].append(entry)
 
     def getTarget(self, name):
         for t in self.targets:

--- a/tests/unit/core/ecu/test_ecu_database.py
+++ b/tests/unit/core/ecu/test_ecu_database.py
@@ -1,0 +1,99 @@
+import json
+import zipfile
+
+from ddt4all.core.ecu.ecu_database import EcuDatabase
+
+
+def test_vehiclemap_keeps_full_project_codes_from_json_targets(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    json_dir = tmp_path / "json"
+    json_dir.mkdir()
+    (json_dir / "test.json.targets").write_text(
+        json.dumps(
+            [
+                {
+                    "diagnostic_version": "01",
+                    "supplier_code": "SUPPLIER",
+                    "soft_version": "SOFT",
+                    "version": "0001",
+                    "group": "UCH",
+                    "projects": ["X95PH2"],
+                    "protocol": "CAN",
+                    "address": "26",
+                }
+            ]
+        )
+    )
+
+    database = EcuDatabase()
+
+    assert database.vehiclemap == {"X95PH2": [("CAN", "26")]}
+
+
+def test_vehiclemap_keeps_full_project_codes_from_zip_database(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    dbdict = {
+        "test.json": {
+            "group": "UCH",
+            "protocol": "CAN",
+            "projects": ["X95PH2"],
+            "address": "26",
+            "ecuname": "Test ECU",
+            "autoidents": [
+                {
+                    "diagnostic_version": "01",
+                    "supplier_code": "SUPPLIER",
+                    "soft_version": "SOFT",
+                    "version": "0001",
+                }
+            ],
+        }
+    }
+    with zipfile.ZipFile("ecu.zip", mode="w") as zf:
+        zf.writestr("db.json", json.dumps(dbdict))
+
+    database = EcuDatabase()
+
+    assert database.vehiclemap == {"X95PH2": [("CAN", "26")]}
+
+
+def test_vehiclemap_keeps_full_project_codes_from_xml_database(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    ecus_dir = tmp_path / "ecus"
+    ecus_dir.mkdir()
+    (ecus_dir / "eculist.xml").write_text(
+        """\
+<ECUlist>
+  <Function Address="38">
+    <Target group="UCH" href="test.xml" Name="Test ECU">
+      <Protocol>CAN</Protocol>
+      <Projects>
+        <X95PH2/>
+      </Projects>
+      <AutoIdents>
+        <AutoIdent
+          DiagVersion="01"
+          Supplier="SUPPLIER"
+          Soft="SOFT"
+          Version="0001"
+        />
+      </AutoIdents>
+    </Target>
+  </Function>
+</ECUlist>
+"""
+    )
+
+    database = EcuDatabase()
+
+    assert database.vehiclemap == {"X95PH2": [("CAN", "26")]}
+
+
+def test_vehiclemap_does_not_truncate_project_codes(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    database = EcuDatabase()
+    database.vehiclemap = {}
+
+    database.addVehicleMapEntry("X95PH2", "CAN", "26")
+
+    assert database.vehiclemap == {"X95PH2": [("CAN", "26")]}


### PR DESCRIPTION
## Summary
- preserve full project codes when building the ECU vehicle map
- keep project filters such as X95 and X95PH2 separate instead of truncating to the first three characters
- add isolated unit coverage for JSON targets, ZIP database, and XML database project mapping

## Tests
- venv/bin/python -m ruff check src/ddt4all/core/ecu/ecu_database.py tests/unit/core/ecu/test_ecu_database.py
- QT_QPA_PLATFORM=offscreen venv/bin/python -m pytest tests/unit/core/ecu/test_ecu_database.py
- QT_QPA_PLATFORM=offscreen venv/bin/python -m pytest --cov=ddt4all --cov-report=term-missing --cov-report=xml