### PR TITLE
Remove Close button and implement real-time language switching

### DIFF
--- a/src/ddt4all/main.py
+++ b/src/ddt4all/main.py
@@ -122,6 +122,10 @@ def main(argv=None) -> int:
 
         if pc.mode == 0 or pcres == widgets.QDialog.Rejected:
             return 0
+        # Mode 3: Language change - reload dialog without exiting
+        if pc.mode == 3:
+            pc = MainWindowOptions(app)
+            continue
 
         options.opt_can2 = pc.CAN2
 

--- a/src/ddt4all/options.py
+++ b/src/ddt4all/options.py
@@ -261,10 +261,12 @@ def set_carlist_sort_mode(mode):
     save_config()
 
 
-def translator(domain):
+def translator(domain, lang=None):
     load_configuration()
-    # Set up message catalog access
-    t = gettext.translation(domain, str(BASE_DIR / "generated" / "locales"), fallback=True)  # not ok in python 3.11.x, codeset="utf-8")
+    # Use provided language or configuration language
+    target_lang = lang if lang else configuration.get("lang", "en_US")
+    # Set up message catalog access with specific language
+    t = gettext.translation(domain, str(BASE_DIR / "generated" / "locales"), languages=[target_lang], fallback=True)
     return t.gettext
 
 def dtt4all_time():

--- a/src/ddt4all/ui/main_window/main_window_options.py
+++ b/src/ddt4all/ui/main_window/main_window_options.py
@@ -59,6 +59,7 @@ class MainWindowOptions(widgets.QDialog):
         self.selectedportspeed = 38400
         self.adapter = "STD"
         self.raise_port_speed = _("No")
+        self.app = app  # Store app reference for reload
         super(MainWindowOptions, self).__init__(None)
         # Set window icon and title
         appIcon = gui.QIcon(ICON_OBD)
@@ -208,7 +209,6 @@ class MainWindowOptions(widgets.QDialog):
         button_con = widgets.QPushButton(_("Connected mode"))
         button_dmo = widgets.QPushButton(_("Edition mode"))
         button_elm_chk = widgets.QPushButton(_("ELM benchmark"))
-        button_save = widgets.QPushButton(_("Close"))
 
         self.elmchk = button_elm_chk
 
@@ -366,7 +366,6 @@ class MainWindowOptions(widgets.QDialog):
 
         button_layout.addWidget(button_con)
         button_layout.addWidget(button_dmo)
-        button_layout.addWidget(button_save)
         button_layout.addWidget(button_elm_chk)
         layout.addLayout(button_layout)
 
@@ -376,7 +375,6 @@ class MainWindowOptions(widgets.QDialog):
 
         button_con.clicked.connect(self.connectedMode)
         button_dmo.clicked.connect(self.demoMode)
-        button_save.clicked.connect(self.save_config)
         button_elm_chk.clicked.connect(self.check_elm)
 
         self._scan_worker = None
@@ -415,21 +413,22 @@ class MainWindowOptions(widgets.QDialog):
             # Update configuration
             options.configuration["lang"] = lang_code
 
-            # Update environment variable
+            # Update environment variable BEFORE saving
             os.environ['LANG'] = lang_code
 
             # Save configuration
             options.save_config()
 
-            # Reinitialize the global translator with new language
-            global _
-            _ = options.translator('ddt4all')
+            # Force reload configuration to apply new language
+            options.load_configuration()
 
-            # Close current window and return to main flow
-            # This will allow the main application to recreate everything with new language
-            self.mode = 0  # Set mode to 0 to trigger restart in main loop
-            self.done(True)
-            exit(0)
+            # Reinitialize the global translator with new language BEFORE reload
+            global _
+            _ = options.translator('ddt4all', lang_code)
+
+            # Close dialog to trigger reload in main loop
+            self.mode = 3  # Set mode to 3 to trigger language reload
+            self.accept()
 
     def update_doip_scan_realtime(self, checked):
         """Update DoIP scan configuration in real-time when checkbox changes"""


### PR DESCRIPTION
- Remove Close button from options dialog
- Implement real-time language change with dialog reload
- Add language parameter to translator function for explicit language control
- Add mode=3 to trigger dialog reload without application exit
- Improve language change UX by forcing configuration reload before translation update