### PR TITLE
Implement real-time DoIP scan toggle with device list visibility control

### DIFF
--- a/src/ddt4all/core/elm/elm.py
+++ b/src/ddt4all/core/elm/elm.py
@@ -150,24 +150,27 @@ def get_available_ports():
     # DoIP devices - Use configured IP address instead of hardcoded values
     doip_target_ip = getattr(options, 'doip_target_ip', '192.168.0.12')
     doip_target_port = getattr(options, 'doip_target_port', 13400)
+    doip_scan_enabled = options.configuration.get('doip_scan', True)
 
-    doip_devices = [
-        (doip_target_ip, f"DoIP Device - {doip_target_ip}:{doip_target_port}"),
-    ]
+    # Only add DoIP devices if scan is enabled
+    if doip_scan_enabled:
+        doip_devices = [
+            (doip_target_ip, f"DoIP Device - {doip_target_ip}:{doip_target_port}"),
+        ]
 
-    # Only check DoIP status if not in simulation mode and not checking too frequently
-    if not getattr(options, 'simulation_mode', False) and not hasattr(get_available_ports, '_last_check_time'):
-        get_available_ports._last_check_time = time.time()
-        for ip, desc in doip_devices:
-            status = check_doip_status(ip, doip_target_port, timeout=0.5)  # Use configured port
-            port_entry = (f"{ip}:{doip_target_port}", desc, "DoIP", status)
-            ports.append(port_entry)
-            print(f"DoIP device {status}: {desc} at {ip}")
-    else:
-        # Use cached status or assume offline
-        for ip, desc in doip_devices:
-            port_entry = (f"{ip}:{doip_target_port}", desc, "DoIP", "offline")
-            ports.append(port_entry)
+        # Only check DoIP status if not in simulation mode and not checking too frequently
+        if not getattr(options, 'simulation_mode', False) and not hasattr(get_available_ports, '_last_check_time'):
+            get_available_ports._last_check_time = time.time()
+            for ip, desc in doip_devices:
+                status = check_doip_status(ip, doip_target_port, timeout=0.5)  # Use configured port
+                port_entry = (f"{ip}:{doip_target_port}", desc, "DoIP", status)
+                ports.append(port_entry)
+                print(f"DoIP device {status}: {desc} at {ip}")
+        else:
+            # Use cached status or assume offline
+            for ip, desc in doip_devices:
+                port_entry = (f"{ip}:{doip_target_port}", desc, "DoIP", "offline")
+                ports.append(port_entry)
 
     # Then check for serial ports
     try:

--- a/src/ddt4all/ui/main_window/main_window_options.py
+++ b/src/ddt4all/ui/main_window/main_window_options.py
@@ -436,6 +436,65 @@ class MainWindowOptions(widgets.QDialog):
         options.configuration["doip_scan"] = bool(checked)
         # Save to config.json immediately
         options.save_config()
+        
+        # Update DoIP button visibility
+        self.doipbutton.setVisible(bool(checked))
+        
+        # Update device list based on scan status
+        if checked:
+            # Add DoIP device to list
+            self._add_doip_device_to_list()
+        else:
+            # Remove DoIP device from list
+            self._remove_doip_device_from_list()
+
+    def _add_doip_device_to_list(self):
+        """Add DoIP device to the device list"""
+        try:
+            # Get current DoIP configuration
+            doip_ip = getattr(options, 'doip_target_ip', '192.168.0.12')
+            doip_port = getattr(options, 'doip_target_port', 13400)
+            
+            # Check if DoIP device already exists in list
+            itemname = f"{doip_ip}:{doip_port}[DoIP Device - {doip_ip}:{doip_port}]"
+            for i in range(self.listview.count()):
+                item = self.listview.item(i)
+                if item.text() == itemname:
+                    return  # Already exists, don't add duplicate
+            
+            # Add DoIP device to list
+            item = widgets.QListWidgetItem(self.listview)
+            item.setText(itemname)
+            item.setBackground(gui.QColor(150, 50, 50))  # Dark red for offline
+            self.ports[itemname] = (f"{doip_ip}:{doip_port}", f"DoIP Device - {doip_ip}:{doip_port}", "", "offline")
+            
+            print(_("DoIP device added to list: %(ip)s:%(port)s") % {"ip": doip_ip, "port": doip_port})
+        except Exception as e:
+            print(_("Error adding DoIP device to list: %s") % e)
+
+    def _remove_doip_device_from_list(self):
+        """Remove DoIP device from the device list"""
+        try:
+            # Find and remove all DoIP devices
+            items_to_remove = []
+            for i in range(self.listview.count()):
+                item = self.listview.item(i)
+                item_text = item.text()
+                if 'DoIP Device' in item_text:
+                    items_to_remove.append(item)
+            
+            # Remove DoIP devices
+            for item in items_to_remove:
+                row = self.listview.row(item)
+                itemname = item.text()
+                if itemname in self.ports:
+                    del self.ports[itemname]
+                self.listview.takeItem(row)
+            
+            if items_to_remove:
+                print(_("DoIP device removed from list"))
+        except Exception as e:
+            print(_("Error removing DoIP device from list: %s") % e)
 
     def check_elm(self):
         """Enhanced ELM connection checker with better error handling"""
@@ -989,19 +1048,20 @@ class MainWindowOptions(widgets.QDialog):
             # Get current DoIP configuration
             doip_ip = getattr(options, 'doip_target_ip', '192.168.0.12')
             doip_port = getattr(options, 'doip_target_port', 13400)
+            doip_scan_enabled = options.configuration.get('doip_scan', True)
             
             # Clear the device list completely - no rescan_ports()
             self.listview.clear()
             self.ports = {}
             self.portcount = 0
             
-            # Add only DoIP device - no COM port scanning
-
-            item = widgets.QListWidgetItem(self.listview)
-            itemname = f"{doip_ip}:{doip_port}[DoIP Device - {doip_ip}:{doip_port}]"
-            item.setText(itemname)
-            item.setBackground(gui.QColor(150, 50, 50))  # Dark red for offline
-            self.ports[itemname] = (f"{doip_ip}:{doip_port}", f"DoIP Device - {doip_ip}:{doip_port}", "", "offline")
+            # Add DoIP device only if scan is enabled
+            if doip_scan_enabled:
+                item = widgets.QListWidgetItem(self.listview)
+                itemname = f"{doip_ip}:{doip_port}[DoIP Device - {doip_ip}:{doip_port}]"
+                item.setText(itemname)
+                item.setBackground(gui.QColor(150, 50, 50))  # Dark red for offline
+                self.ports[itemname] = (f"{doip_ip}:{doip_port}", f"DoIP Device - {doip_ip}:{doip_port}", "", "offline")
             
         except Exception as e:
             print(_("Error in force DoIP update: %s") % e)
@@ -1030,6 +1090,7 @@ class MainWindowOptions(widgets.QDialog):
             # Get current DoIP configuration
             doip_ip = getattr(options, 'doip_target_ip', '192.168.0.12')
             doip_port = getattr(options, 'doip_target_port', 13400)
+            doip_scan_enabled = options.configuration.get('doip_scan', True)
             
             # Find and remove existing DoIP device
             items_to_remove = []
@@ -1042,16 +1103,21 @@ class MainWindowOptions(widgets.QDialog):
             # Remove old DoIP devices
             for item in items_to_remove:
                 row = self.listview.row(item)
+                itemname = item.text()
+                if itemname in self.ports:
+                    del self.ports[itemname]
                 self.listview.takeItem(row)
                 
-            # Add new DoIP device
-            item = widgets.QListWidgetItem(self.listview)
-            itemname = f"{doip_ip}:{doip_port}[DoIP Device - {doip_ip}:{doip_port}]"
-            item.setText(itemname)
-            item.setBackground(core.QColor(150, 50, 50))  # Dark red for offline
-            self.ports[itemname] = (f"{doip_ip}:{doip_port}", f"DoIP Device - {doip_ip}:{doip_port}", "", "offline")
-            
-            print(_("DoIP device updated: %(ip)s:%(port)s") % {"ip": doip_ip, "port": doip_port})
+            # Add new DoIP device only if scan is enabled
+            if doip_scan_enabled:
+                item = widgets.QListWidgetItem(self.listview)
+                itemname = f"{doip_ip}:{doip_port}[DoIP Device - {doip_ip}:{doip_port}]"
+                item.setText(itemname)
+                item.setBackground(gui.QColor(150, 50, 50))  # Dark red for offline
+                self.ports[itemname] = (f"{doip_ip}:{doip_port}", f"DoIP Device - {doip_ip}:{doip_port}", "", "offline")
+                print(_("DoIP device updated: %(ip)s:%(port)s") % {"ip": doip_ip, "port": doip_port})
+            else:
+                print(_("DoIP device removed from list (scan disabled)"))
             
         except Exception as e:
             print(_("Error in targeted DoIP update: %s") % e)


### PR DESCRIPTION
This change implements real-time DoIP scan toggle functionality that allows users to enable/disable DoIP device scanning and immediately see the DoIP device appear or disappear from the device list, both during runtime and upon application restart.

Problem:
- Previously, the DoIP scan checkbox only updated configuration but didn't affect the device list visibility in real-time
- DoIP devices would always appear in the device list at startup regardless of the doip_scan configuration setting
- Users had to restart the application for DoIP scan changes to take effect

Solution:
- Implemented real-time DoIP scan toggle that immediately updates device list
- Added configuration check at startup to respect doip_scan setting
- Created helper functions to add/remove DoIP devices from the list dynamically

Changes in main_window_options.py:
- Enhanced update_doip_scan_realtime() to:
  * Update DoIP button visibility based on scan state
  * Add/remove DoIP device from list when checkbox toggled
- Added _add_doip_device_to_list() to:
  * Dynamically add DoIP device to device list
  * Check for duplicates to prevent multiple entries
  * Use current DoIP configuration (IP, port)
  * Fixed QColor import (gui.QColor instead of core.QColor)
- Added _remove_doip_device_from_list() to:
  * Remove all DoIP devices from device list
  * Clean up ports dictionary entries
- Updated _force_doip_update() to:
  * Check doip_scan configuration before adding device
  * Only add DoIP device when scan is enabled
- Updated _update_doip_device_only() to:
  * Check doip_scan configuration before adding device
  * Improve ports dictionary cleanup
  * Only add DoIP device when scan is enabled

Changes in elm.py:
- Modified get_available_ports() function to:
  * Check doip_scan configuration before adding DoIP devices
  * Only add DoIP devices to available ports when scan is enabled
  * Ensure consistent behavior at application startup

User Experience:
- When enabling DoIP scan: device immediately appears in list, button becomes visible
- When disabling DoIP scan: device immediately disappears from list, button becomes hidden
- Configuration persists across application restarts
- Behavior is now consistent whether toggling during runtime or starting with different config

Technical Details:
- Configuration is saved immediately to config.json when checkbox is toggled
- Device list updates are performed in real-time without requiring application restart
- Error handling includes user-friendly messages for debugging
- DoIP device uses dark red background to indicate offline status