### PR TITLE
Fix translator configuration on machines where system language cannot be detected

### DIFF
--- a/src/ddt4all/options.py
+++ b/src/ddt4all/options.py
@@ -134,7 +134,7 @@ def load_configuration():
         f = open(get_config_dir() / "config.json", "r", encoding="UTF-8")
         config = json.loads(f.read())
         # load config as multiplatform (mac fix macOs load conf)
-        configuration["lang"] = config.get("lang", get_translator_lang())
+        configuration["lang"] = config.get("lang") or get_translator_lang()  # get default lang if value in config is not set or None
         configuration["dark"] = config.get("dark", False)
         configuration["socket_timeout"] = config.get("socket_timeout", False)
         
@@ -190,11 +190,15 @@ def get_translator_lang():
     loc_lang = "en_US"
     try:
         lang, enc = locale.getdefaultlocale()
-        loc_lang = lang
+        if lang:
+            # set value only if lang is detected
+            loc_lang = lang
     except Exception:
         try:
             lang, enc = locale.getlocale()
-            loc_lang = lang
+            if lang:
+                # set value only if lang is detected
+                loc_lang = lang
         except Exception:
             pass
     return loc_lang
@@ -306,11 +310,12 @@ def clear_history():
 def translator(domain, lang=None):
     load_configuration()
     # Use provided language or configuration language
-    target_lang = lang if lang else configuration.get("lang", "en_US")
+    target_lang = lang if lang else (configuration.get("lang") or "en_US")
     # Set up message catalog access with specific language
     global _current_translation
     _current_translation = gettext.translation(domain, str(BASE_DIR / "generated" / "locales"), languages=[target_lang], fallback=True)
     return _dynamic_gettext
+
 
 def dtt4all_time():
     if (sys.version_info[0] * 100 + sys.version_info[1]) > 306:


### PR DESCRIPTION
According to python library docs, functions `locale.getdefaultlocale()` and `locale.getlocale()` can return `None` for language code if language is not determined. These functions are used to create or update `config.json`, so `lang` field in configuration dict and/or `config.json` might contain `None` value instead of proper language code string. But function `gettext.translation()` expects language values are strings, not `None` values.

This PR fixes `lang` value in config and ensures string value is passed to `gettext.translation()` as languages item, not `None`.

The fix is related to all supported python versions (3.8-3.13) and python 3.14 (which is not marked as supported yet).

Example of exception before fix:
```
Traceback (most recent call last):
  File "/Users/user/ddt4all/venv/bin/ddt4all", line 3, in <module>
    from ddt4all.main import main
  File "/Users/user/ddt4all/src/ddt4all/main.py", line 10, in <module>
    from ddt4all.cli.cli_args_parser import build_parser
  File "/Users/user/ddt4all/src/ddt4all/cli/cli_args_parser.py", line 9, in <module>
    from ddt4all.cli.cmd_handlers.doip import cmd_doip
  File "/Users/user/ddt4all/src/ddt4all/cli/cmd_handlers/doip.py", line 19, in <module>
    from ddt4all.core.doip.doip_devices import DoIPDevice
  File "/Users/user/ddt4all/src/ddt4all/core/doip/doip_devices.py", line 1, in <module>
    from ddt4all.core.doip.doip_connection import DoIPConnection
  File "/Users/user/ddt4all/src/ddt4all/core/doip/doip_connection.py", line 8, in <module>
    _ = options.translator('ddt4all')
  File "/Users/user/ddt4all/src/ddt4all/options.py", line 312, in translator
    _current_translation = gettext.translation(domain, str(BASE_DIR / "generated" / "locales"), languages=[target_lang], fallback=True)
  File "/usr/local/Cellar/python@3.14/3.14.6/Frameworks/Python.framework/Versions/3.14/lib/python3.14/gettext.py", line 532, in translation
    mofiles = find(domain, localedir, languages, all=True)
  File "/usr/local/Cellar/python@3.14/3.14.6/Frameworks/Python.framework/Versions/3.14/lib/python3.14/gettext.py", line 504, in find
    for nelang in _expand_lang(lang):
                  ~~~~~~~~~~~~^^^^^^
  File "/usr/local/Cellar/python@3.14/3.14.6/Frameworks/Python.framework/Versions/3.14/lib/python3.14/gettext.py", line 233, in _expand_lang
    loc = locale.normalize(loc)
  File "/usr/local/Cellar/python@3.14/3.14.6/Frameworks/Python.framework/Versions/3.14/lib/python3.14/locale.py", line 403, in normalize
    code = localename.lower()
           ^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'lower'

```

After the fix:
* First app run, when config is not created yet: `config.json` is created with `en_US` as language if system language not determined
* App run when `config.json` already exists with missing `lang` field or if value is None: `lang` field is updated to determined system language or to 'en_US' value if language is not determined
* App run when `config.json` contains valid language code, or when system language is determined: the app works as before the fix

