### PR TITLE
Fixed config file loading if app run not from src dir

### DIFF
--- a/src/ddt4all/file_manager.py
+++ b/src/ddt4all/file_manager.py
@@ -14,7 +14,7 @@ def is_run_from_src():
 
 def get_dir(dir_name):
     if is_run_from_src():
-        path =  BASE_DIR / ".." / ".." / dir_name
+        path =  Path(BASE_DIR / ".." / ".." / dir_name)
     else:
         path = Path(dir_name)
 

--- a/src/ddt4all/file_manager.py
+++ b/src/ddt4all/file_manager.py
@@ -4,32 +4,38 @@ from pathlib import Path
 BASE_DIR = Path(__file__).resolve().parent
 icons_base_dir = BASE_DIR / "resources" / "icons"
 
+
 def is_run_from_src():
     return (
         BASE_DIR.name == "ddt4all" and
         BASE_DIR.parent.name == "src"
     )
 
+
 def get_dir(dir_name):
-
     if is_run_from_src():
-
-        return BASE_DIR / ".." / ".." / dir_name
-
+        path =  BASE_DIR / ".." / ".." / dir_name
     else:
-        return dir_name
+        path = Path(dir_name)
+
+    return path.resolve()
+
 
 def get_json_dir():
     return get_dir("json")
 
+
 def get_logs_dir():
     return get_dir("logs")
+
 
 def get_vehicles_dir():
     return get_dir("vehicles")
 
+
 def get_config_dir():
     return get_dir(".")
+
 
 def is_not_package_file(path):
     return not path.endswith("__init__.py")


### PR DESCRIPTION
Function `ddt4all.options::load_configuration()` expects that `get_config_dir()` returns Path object, but before the fix it could return string object in some cases.

`get_dir()` now always returns `Path` class instance. All the places are reviewed where `get_dir()` and `get_*_dir()` are used, and they are all compatible with `Path` class instance

Also, `get_dir()` now returns resolved absolute path to ensure proper path is used if app changes current working directory.


Example of exception:
```
Traceback (most recent call last):
  File "/Users/user/ddt4all/src/ddt4all/options.py", line 134, in load_configuration
    f = open(get_config_dir() / "config.json", "r", encoding="UTF-8")
             ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
TypeError: unsupported operand type(s) for /: 'str' and 'str'

```