### PR TITLE
Fixed translation logic

### DIFF
--- a/src/ddt4all/options.py
+++ b/src/ddt4all/options.py
@@ -301,11 +301,12 @@ def clear_history():
 def translator(domain, lang=None):
     load_configuration()
     # Use provided language or configuration language
-    target_lang = lang if lang else configuration.get("lang", lang_list["Default"])
+    target_lang = lang if lang else (configuration.get("lang") or lang_list["Default"])
     # Set up message catalog access with specific language
     global _current_translation
-    _current_translation = gettext.translation(domain, str(BASE_DIR / "generated" / "locales"), languages=[str(target_lang)], fallback=True)
+    _current_translation = gettext.translation(domain, str(BASE_DIR / "generated" / "locales"), languages=[target_lang], fallback=True)
     return _dynamic_gettext
+
 
 def dtt4all_time():
     if (sys.version_info[0] * 100 + sys.version_info[1]) > 306:


### PR DESCRIPTION
This PR ensures proper language configuration is set for `gettext.translator()`

Changed logic of the function `ddt4all.options::translator()`:
* Use configured language instead of default.
* If configured language is None, fallback to default language.

Currently, 'en_US' is always passed to `gettext.translator()` on app start, because `ddt4all.options::translator()` is called without `lang` parameter, and it defaults to `lang_list["Default"]`, which is `en_US`. In that case configured language is not used:
```python
def translator(domain, lang=lang_list["Default"]):
    load_configuration()
    # Use provided language or configuration language
    target_lang = lang if lang else configuration.get("lang", lang_list["Default"])
    ...
```
Changing function definition to `def translator(domain, lang=None):` resolves improper lang code usage.

Then, changing line:
```python
target_lang = lang if lang else configuration.get("lang", lang_list["Default"])
```
to the line:
```python
target_lang = lang if lang else (configuration.get("lang") or lang_list["Default"])
```
ensures that `target_lang` is set to proper language code if `configuration["lang"]` is `None`. ( it can be `None` because `get_translator_lang()` call in `load_configuration()` and `create_new_config()` can return None)

Last, changing line:
```python
_current_translation = gettext.translation(domain, str(BASE_DIR / "generated" / "locales"), languages=[str(target_lang)], fallback=True)
```
to the line:
```python
_current_translation = gettext.translation(domain, str(BASE_DIR / "generated" / "locales"), languages=[target_lang], fallback=True)
```
removes redundant conversion from string to string, because `target_lang` can be only string at this point.
