### PR TITLE
Fixed label widget initialization

### DIFF
--- a/src/ddt4all/ui/displaymod/label_widget.py
+++ b/src/ddt4all/ui/displaymod/label_widget.py
@@ -67,7 +67,7 @@ class LabelWidget(widgets.QLabel):
                 # Ensure the path is a string and the file exists
                 if isinstance(imgname, str) and os.path.exists(imgname):
                     self.img = gui.QMovie(imgname)
-            if self.img.isValid():
+            elif self.img.isValid():
                 self.setMovie(self.img)
                 self.img.start()
             else:
@@ -115,7 +115,7 @@ class LabelWidget(widgets.QLabel):
                 # Ensure the path is a string and the file exists
                 if isinstance(imgname, str) and os.path.exists(imgname):
                     self.img = gui.QMovie(imgname)
-            if self.img.isValid():
+            elif self.img.isValid():
                 self.setMovie(self.img)
                 self.img.start()
             else:


### PR DESCRIPTION
This PR resolves crash on label widget initialization.

Example of traceback:
```
Traceback (most recent call last):
  File "/Users/user/ddt4all/src/ddt4all/ui/main_window/main_widget.py", line 1062, in changeScreen
    inited = self.paramview.init(screen, self.screenlogfile)
  File "/Users/user/ddt4all/src/ddt4all/ui/parameters/param_widget.py", line 453, in init
    scr_init = self.initScreen(screen)
  File "/Users/user/ddt4all/src/ddt4all/ui/parameters/param_widget.py", line 815, in initScreen
    self.drawLabels(screen)
    ~~~~~~~~~~~~~~~^^^^^^^^
  File "/Users/user/ddt4all/src/ddt4all/ui/parameters/param_widget.py", line 905, in drawLabels
    qlabel.initJson(label)
    ~~~~~~~~~~~~~~~^^^^^^^
  File "/Users/user/ddt4all/src/ddt4all/ui/displaymod/label_widget.py", line 118, in initJson
    if self.img.isValid():
       ^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'isValid'

```

It can be reproduced by choosing item in `Screen window`.