### PR TITLE
Fix/macos install packaging and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,32 @@ sudo apt-get install --reinstall libxcb-xinerama0
 python -m ddt4all
 ```
 
+### **macOS Installation Notes**
+If you are on macOS and `pip install -e .` fails with an editable install error, upgrade packaging tools first:
+
+```bash
+python3 -m pip install --upgrade pip setuptools wheel
+python3 -m pip install -e .
+```
+
+If DDT4All starts with:
+`resources/projects.json not found or invalid`
+
+reinstall from the repository root so package data is available:
+
+```bash
+cd ddt4all
+python3 -m pip install --force-reinstall -e .
+```
+
+Quick launch commands on macOS:
+
+```bash
+ddt4all
+# or
+python3 -m ddt4all
+```
+
 ---
 
 ## 🚀 **Quick Launch**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,12 @@ package-dir = {"" = "src"}
 [tool.setuptools.packages.find]
 where = ["src"]
 
+[tool.setuptools.package-data]
+ddt4all = [
+    "resources/*.json",
+    "generated/locales/*/LC_MESSAGES/*.mo",
+]
+
 [tool.pytest.ini_options]
 testpaths = ["tests/integration", "tests/unit", "tests/smoke"]
 addopts = "-q"

--- a/setup_tools/README.md
+++ b/setup_tools/README.md
@@ -97,6 +97,9 @@ cd ddt4all
 python3 -m venv ./venv
 source ./venv/bin/activate
 
+# Upgrade packaging tools (recommended on macOS)
+python3 -m pip install --upgrade pip setuptools wheel
+
 # Install dependencies including PyInstaller
 pip install -e ".[dev]"
 pip install pyinstaller
@@ -245,9 +248,14 @@ The build systems automatically sync version information from:
 
 ### macOS Build Issues
 - **PyInstaller fails**: Check for missing hidden imports
+- **Editable install fails**: Upgrade tooling, then retry:
+  `python3 -m pip install --upgrade pip setuptools wheel`
 - **Code signing errors**: Ensure proper certificates installed
 - **Universal binary issues**: Build on both architectures or use universal tools
 - **Notarization failures**: Check entitlements and signing identity
+- **`resources/projects.json not found or invalid` at startup**:
+  Reinstall from repository root so package data is present:
+  `python3 -m pip install --force-reinstall -e .`
 
 ### Linux Build Issues
 - **Missing system dependencies**: Install development headers


### PR DESCRIPTION
Summary
This PR improves macOS installation reliability for source installs and aligns setup documentation with the current packaging behavior.

What changed
Added package data configuration so runtime files are included in built/installed distributions:
[ddt4all/resources/projects.json](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[ddt4all/generated/locales/*/LC_MESSAGES/*.mo](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Added macOS troubleshooting notes to the main README:
Upgrade pip, setuptools, and wheel before editable installs
Recovery steps for resources/projects.json not found or invalid
Verified launch commands ([ddt4all](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [python3 -m ddt4all](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html))
Added matching macOS guidance in build docs ([README.md](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)) for consistency.
Why
On macOS, users with older packaging tooling can fail on [pip install -e .](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html), and some installs may miss runtime data files required at startup, causing:
resources/projects.json not found or invalid.

This PR addresses both causes:

Documentation now clearly describes the required tooling upgrade/reinstall path.
Packaging now explicitly includes required runtime resource and locale files.
Validation
Verified locally on macOS:

pip install --force-reinstall . installs package with required runtime files present.
[ddt4all --help](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) works after installation.
resources/projects.json resolves correctly from installed package.
Scope
Packaging metadata and documentation only.
No ECU logic, protocol behavior, or UI runtime logic changes.