### PR TITLE
Appimage Build. 

### DIFF
--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -1,0 +1,56 @@
+name: Build AppImage
+
+on:
+  push:
+    tags:
+      - 'v*'
+      - '[0-9]+.[0-9]+.[0-9]+*'
+  release:
+    types: [published]
+
+jobs:
+  appimage:
+    name: Linux AppImage
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: "pip"
+
+      - name: Install system deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libxcb-xinerama0 \
+            libgl1 \
+            libfuse2 \
+            libbluetooth-dev
+
+      - name: Install Python deps
+        run: |
+          pip install --upgrade pip
+          pip install -e ".[can,network,bluetooth]"
+
+      - name: Build AppImage
+        run: |
+          bash setup_tools/appimage/build.sh "${GITHUB_REF_NAME}"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ddt4all-x86_64.AppImage
+          path: ddt4all-*.AppImage
+          if-no-files-found: error
+
+      - name: Upload to Release
+        if: github.ref_type == 'tag'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ddt4all-*.AppImage
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ __pycache__/
 coverage.xml
 /scripts/resources.qrc
 *.po~
+ddt4all-*.AppImage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,8 @@ dependencies = [
 
     # Safe ranges to avoid breaking changes
     "polib>=1.2.0,<2.0.0",
+
+    "platformdirs>=3.0.0,<4.0",
 ]
 
 [project.optional-dependencies]

--- a/setup_tools/appimage/build.sh
+++ b/setup_tools/appimage/build.sh
@@ -34,16 +34,14 @@ fi
 # --- stdlib + venv site-packages ---
 # D'abord copier le site-packages du venv (contient PyQt5, pyserial, etc.)
 cp -r "$PYTHON_STDLIB/site-packages" "$APPDIR/usr/lib/python${PYTHON_VER}/"
-# Puis la stdlib système (encodings, os.py, etc.) sans écraser site-packages
-SYS_STDLIB="$(python3 -c "import os; print(os.path.dirname(os.__file__))")"
-if [ -d "$SYS_STDLIB" ] && [ "$(readlink -f "$SYS_STDLIB")" != "$(readlink -f "$PYTHON_STDLIB")" ]; then
-  for item in "$SYS_STDLIB"/*; do
-    bn="$(basename "$item")"
-    if [ "$bn" != "site-packages" ]; then
-      cp -r "$item" "$APPDIR/usr/lib/python${PYTHON_VER}/" 2>/dev/null || true
-    fi
-  done
-fi
+# Puis la stdlib système (encodings, os.py, etc.) depuis l'interpréteur courant
+STDLIB="$(python3 -c "import os; print(os.path.dirname(os.__file__))")"
+for item in "$STDLIB"/*; do
+  bn="$(basename "$item")"
+  if [ "$bn" != "site-packages" ] && [ "$bn" != "__pycache__" ]; then
+    cp -rn "$item" "$APPDIR/usr/lib/python${PYTHON_VER}/" 2>/dev/null || true
+  fi
+done
 
 # --- Installer ddt4all (écrase l'édition éditable du venv) ---
 pip install --upgrade --no-deps --force-reinstall --target "$APPDIR/usr/lib/python${PYTHON_VER}/site-packages" .

--- a/setup_tools/appimage/build.sh
+++ b/setup_tools/appimage/build.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+set -e
+
+VERSION="${1:-$(git describe --tags --always 2>/dev/null || echo "dev")}"
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+APPDIR="$ROOT/build/AppDir"
+TOOLSDIR="$ROOT/build/tools"
+
+PYTHON_BIN="$(which python3)"
+PYTHON_VER="$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
+PYTHON_LIB="$(dirname "$PYTHON_BIN")/../lib/libpython${PYTHON_VER}.so.1.0"
+PYTHON_STDLIB="$(dirname "$PYTHON_BIN")/../lib/python${PYTHON_VER}"
+
+echo "=== Build AppImage ==="
+echo "Version:   $VERSION"
+echo "Python:    $PYTHON_BIN ($PYTHON_VER)"
+echo "Output:    ddt4all-${VERSION}-x86_64.AppImage"
+
+rm -rf "$APPDIR" "$TOOLSDIR"
+mkdir -p "$APPDIR/usr/bin" "$APPDIR/usr/lib" \
+         "$APPDIR/usr/share/applications" \
+         "$APPDIR/usr/share/icons/hicolor/256x256/apps"
+
+# --- Python binaire ---
+cp "$PYTHON_BIN" "$APPDIR/usr/bin/python${PYTHON_VER}"
+ln -sf "python${PYTHON_VER}" "$APPDIR/usr/bin/python3"
+
+# --- libpython ---
+if [ -f "$PYTHON_LIB" ]; then
+  cp "$PYTHON_LIB" "$APPDIR/usr/lib/"
+  cp -a "$(dirname "$PYTHON_LIB")/libpython${PYTHON_VER}.so" "$APPDIR/usr/lib/" 2>/dev/null || true
+fi
+
+# --- stdlib + venv site-packages ---
+# D'abord copier le site-packages du venv (contient PyQt5, pyserial, etc.)
+cp -r "$PYTHON_STDLIB/site-packages" "$APPDIR/usr/lib/python${PYTHON_VER}/"
+# Puis la stdlib système (encodings, os.py, etc.) sans écraser site-packages
+SYS_STDLIB="$(python3 -c "import os; print(os.path.dirname(os.__file__))")"
+if [ -d "$SYS_STDLIB" ] && [ "$(readlink -f "$SYS_STDLIB")" != "$(readlink -f "$PYTHON_STDLIB")" ]; then
+  for item in "$SYS_STDLIB"/*; do
+    bn="$(basename "$item")"
+    if [ "$bn" != "site-packages" ]; then
+      cp -r "$item" "$APPDIR/usr/lib/python${PYTHON_VER}/" 2>/dev/null || true
+    fi
+  done
+fi
+
+# --- Installer ddt4all (écrase l'édition éditable du venv) ---
+pip install --upgrade --no-deps --force-reinstall --target "$APPDIR/usr/lib/python${PYTHON_VER}/site-packages" .
+
+# --- Icône ---
+cp resources/icons/obd.png "$APPDIR/usr/share/icons/hicolor/256x256/apps/ddt4all.png"
+cp "$APPDIR/usr/share/icons/hicolor/256x256/apps/ddt4all.png" "$APPDIR/ddt4all.png"
+
+# --- Desktop file ---
+cat > "$APPDIR/usr/share/applications/ddt4all.desktop" << EOF
+[Desktop Entry]
+Name=DDT4All
+Comment=CAN bus ECU diagnostic tool
+Categories=Development;Electronics;
+Exec=ddt4all
+Icon=ddt4all
+Type=Application
+Terminal=false
+EOF
+cp "$APPDIR/usr/share/applications/ddt4all.desktop" "$APPDIR/"
+
+# --- AppRun ---
+cat > "$APPDIR/AppRun" << APPRUN
+#!/bin/bash
+set -e
+APPDIR="\$(dirname "\$(readlink -f "\$0")")"
+export PATH="\$APPDIR/usr/bin:\$PATH"
+export LD_LIBRARY_PATH="\$APPDIR/usr/lib:\$APPDIR/lib:\$LD_LIBRARY_PATH"
+export PYTHONHOME="\$APPDIR/usr"
+export PYTHONPATH="\$APPDIR/usr/lib/python${PYTHON_VER}/site-packages"
+export QT_QPA_PLATFORM=xcb
+export QT_PLUGIN_PATH="\$APPDIR/usr/plugins"
+export QTWEBENGINE_CHROMIUM_FLAGS="--disk-cache-dir=\$HOME/.cache/ddt4all"
+exec "\$APPDIR/usr/bin/python3" -m ddt4all "\$@"
+APPRUN
+chmod +x "$APPDIR/AppRun"
+
+# --- Télécharger les outils ---
+mkdir -p "$TOOLSDIR"
+cd "$TOOLSDIR"
+
+if [ ! -f linuxdeploy-x86_64.AppImage ]; then
+  wget -q "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage" -O linuxdeploy-x86_64.AppImage
+fi
+if [ ! -f linuxdeploy-plugin-qt-x86_64.AppImage ]; then
+  wget -q "https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage" -O linuxdeploy-plugin-qt-x86_64.AppImage
+fi
+if [ ! -f appimagetool-x86_64.AppImage ]; then
+  wget -q "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage" -O appimagetool-x86_64.AppImage
+fi
+
+chmod +x *.AppImage
+
+cd "$ROOT"
+
+# --- Bundler Qt5 ---
+echo "=== Bundling Qt5 ==="
+# Extraire les AppImage tools pour éviter FUSE
+for f in "$TOOLSDIR"/*.AppImage; do
+  bn="$(basename "$f" .AppImage)"
+  out="$TOOLSDIR/$bn"
+  if [ ! -d "$out" ]; then
+    (cd "$TOOLSDIR" && "$f" --appimage-extract && mv squashfs-root "$bn") || true
+  fi
+done
+
+# Nettoyer les plugins QML non essentiels pour éviter les erreurs Qt5 manquants
+rm -rf "$APPDIR/usr/lib/python${PYTHON_VER}/site-packages/PyQt5/Qt5/qml/Qt/labs/lottieqt" 2>/dev/null || true
+rm -rf "$APPDIR/usr/lib/python${PYTHON_VER}/site-packages/PyQt5/Qt5/qml/Qt/labs/sharedimage" 2>/dev/null || true
+rm -rf "$APPDIR/usr/lib/python${PYTHON_VER}/site-packages/PyQt5/Qt5/qml/Qt/labs/wavefrontmesh" 2>/dev/null || true
+rm -rf "$APPDIR/usr/lib/python${PYTHON_VER}/site-packages/PyQt5/Qt5/qml/QtQuick/Pdf" 2>/dev/null || true
+rm -rf "$APPDIR/usr/lib/python${PYTHON_VER}/site-packages/PyQt5/Qt5/qml/QtQuick/Scene2D" 2>/dev/null || true
+rm -rf "$APPDIR/usr/lib/python${PYTHON_VER}/site-packages/PyQt5/Qt5/qml/QtQuick/Particles.2" 2>/dev/null || true
+rm -rf "$APPDIR/usr/lib/python${PYTHON_VER}/site-packages/PyQt5/Qt5/qml/QtQuick/PrivateWidgets" 2>/dev/null || true
+rm -rf "$APPDIR/usr/lib/python${PYTHON_VER}/site-packages/PyQt5/Qt5/qml/QtQuick/Extras" 2>/dev/null || true
+rm -rf "$APPDIR/usr/lib/python${PYTHON_VER}/site-packages/PyQt5/Qt5/qml/Qt3D" 2>/dev/null || true
+rm -rf "$APPDIR/usr/lib/python${PYTHON_VER}/site-packages/PyQt5/Qt5/plugins/geometryloaders" 2>/dev/null || true
+rm -rf "$APPDIR/usr/lib/python${PYTHON_VER}/site-packages/PyQt5/Qt5/plugins/sceneparsers" 2>/dev/null || true
+rm -rf "$APPDIR/usr/lib/python${PYTHON_VER}/site-packages/PyQt5/Qt5/plugins/renderplugins" 2>/dev/null || true
+rm -f "$APPDIR/usr/lib/python${PYTHON_VER}/site-packages/PyQt5/Qt5/plugins/imageformats/libqpdf.so" 2>/dev/null || true
+rm -f "$APPDIR/usr/lib/python${PYTHON_VER}/site-packages/PyQt5/Qt5/plugins/renderers/libopenglrenderer.so" 2>/dev/null || true
+rm -f "$APPDIR/usr/lib/python${PYTHON_VER}/site-packages/PyQt5/Qt5/plugins/sqldrivers/libqsqlodbc.so" 2>/dev/null || true
+rm -f "$APPDIR/usr/lib/python${PYTHON_VER}/site-packages/PyQt5/Qt5/plugins/sqldrivers/libqsqlpsql.so" 2>/dev/null || true
+rm -f "$APPDIR/usr/lib/python${PYTHON_VER}/site-packages/PyQt5/Qt5/plugins/texttospeech/libqtexttospeech_speechd.so" 2>/dev/null || true
+
+LDA="$TOOLSDIR/linuxdeploy-x86_64/AppRun"
+if [ ! -x "$LDA" ]; then
+  LDA="$TOOLSDIR/linuxdeploy-x86_64.AppImage"
+fi
+
+LD_LIBRARY_PATH="" "$LDA" --appdir "$APPDIR" --plugin qt 2>&1 || {
+  echo "WARNING: linuxdeploy-qt a échoué mais on continue"
+}
+
+# --- Créer l'AppImage ---
+echo "=== Creating AppImage ==="
+if [ -x "$TOOLSDIR/appimagetool-x86_64/AppRun" ]; then
+  ARCH=x86_64 "$TOOLSDIR/appimagetool-x86_64/AppRun" "$APPDIR" "$ROOT/ddt4all-${VERSION}-x86_64.AppImage"
+else
+  cd "$TOOLSDIR" && ARCH=x86_64 ./appimagetool-x86_64.AppImage --appimage-extract-and-run "$APPDIR" "$ROOT/ddt4all-${VERSION}-x86_64.AppImage"
+  cd "$ROOT"
+fi
+
+echo ""
+echo "=== Done: ddt4all-${VERSION}-x86_64.AppImage ==="
+ls -lh "ddt4all-${VERSION}-x86_64.AppImage"

--- a/src/ddt4all/core/elm/elm.py
+++ b/src/ddt4all/core/elm/elm.py
@@ -5,6 +5,7 @@
 
 from datetime import datetime
 import glob
+from pathlib import Path
 import os
 import platform
 import serial
@@ -446,8 +447,7 @@ class ELM:
 
             options.port_speed = speed
 
-            if not os.path.exists(get_logs_dir()):
-                os.mkdir(get_logs_dir())
+            Path(get_logs_dir()).mkdir(parents=True, exist_ok=True)
 
             if len(options.log) > 0:
                 self.lf = open(os.path.join(get_logs_dir(), "elm_" + options.log + ".txt"), "at", encoding="utf-8")

--- a/src/ddt4all/file_manager.py
+++ b/src/ddt4all/file_manager.py
@@ -1,7 +1,11 @@
 from pathlib import Path
 
+from platformdirs import PlatformDirs
+
 BASE_DIR = Path(__file__).resolve().parent
 icons_base_dir = BASE_DIR / "resources" / "icons"
+
+_dirs = PlatformDirs("ddt4all")
 
 
 def is_run_from_src():
@@ -11,12 +15,20 @@ def is_run_from_src():
     )
 
 
+def _legacy_exists():
+    return Path("config.json").exists() or Path("json").exists()
+
+
 def get_dir(dir_name):
     if is_run_from_src():
         path = Path(BASE_DIR / ".." / ".." / dir_name)
-    else:
+    elif _legacy_exists():
         path = Path(dir_name)
-
+    else:
+        if dir_name == ".":
+            path = Path(_dirs.user_config_dir)
+        else:
+            path = Path(_dirs.user_data_dir) / dir_name
     return path.resolve()
 
 
@@ -34,6 +46,13 @@ def get_vehicles_dir():
 
 def get_config_dir():
     return get_dir(".")
+
+
+def get_projects_path():
+    user_path = Path(_dirs.user_data_dir) / "projects.json"
+    if user_path.exists():
+        return user_path
+    return BASE_DIR / "resources" / "projects.json"
 
 
 def is_not_package_file(path):

--- a/src/ddt4all/file_manager.py
+++ b/src/ddt4all/file_manager.py
@@ -16,7 +16,11 @@ def is_run_from_src():
 
 
 def _legacy_exists():
-    return Path("config.json").exists() or Path("json").exists()
+    return (
+        Path("config.json").exists()
+        or Path("json").exists()
+        or Path("ecus/eculist.xml").exists()
+    )
 
 
 def get_dir(dir_name):
@@ -37,7 +41,11 @@ def get_json_dir():
 
 
 def get_logs_dir():
-    return get_dir("logs")
+    if is_run_from_src():
+        return (BASE_DIR / "../.." / "logs").resolve()
+    if _legacy_exists():
+        return Path("logs").resolve()
+    return Path(_dirs.user_log_dir)
 
 
 def get_vehicles_dir():

--- a/src/ddt4all/main.py
+++ b/src/ddt4all/main.py
@@ -14,6 +14,7 @@ from ddt4all.file_manager import (
     get_config_dir,
     get_json_dir,
     get_logs_dir,
+    get_projects_path,
 )
 import ddt4all.generated.resources_rc  # noqa: F401
 import ddt4all.options as options
@@ -46,7 +47,7 @@ if sys.platform[:3] == "lin":
 
 def load_this():
     try:
-        with open(BASE_DIR / "resources" / "projects.json", "r", encoding="UTF-8") as f:
+        with open(get_projects_path(), "r", encoding="UTF-8") as f:
             vehicles_loc = json.loads(f.read())
         ecu_db.addressing = vehicles_loc["projects"]["All"]["addressing"]
         # TODO: Review DoIP addressing mapping loaded from projects.json.
@@ -112,10 +113,8 @@ def main(argv=None) -> int:
     if os.path.exists(options.ecus_dir + '/eculist.xml'):
         print(_("Using custom DDT database"))
 
-    if not os.path.exists(get_json_dir()):
-        os.mkdir(get_json_dir())
-    if not os.path.exists(get_logs_dir()):
-        os.mkdir(get_logs_dir())
+    Path(get_json_dir()).mkdir(parents=True, exist_ok=True)
+    Path(get_logs_dir()).mkdir(parents=True, exist_ok=True)
 
     pc = MainWindowOptions(app)
     nok = True

--- a/src/ddt4all/options.py
+++ b/src/ddt4all/options.py
@@ -107,8 +107,10 @@ BASE_DIR = Path(__file__).resolve().parent
 
 def save_config():
     # print(f'Save ddt4all_data/config.json lang: {configuration["lang"]} -> Ok.')
+    config_path = get_config_dir() / "config.json"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
     js = json.dumps(configuration, ensure_ascii=False, indent=True)
-    f = open(str(get_config_dir() / "config.json"), "w", encoding="UTF-8")
+    f = open(str(config_path), "w", encoding="UTF-8")
     f.write(js)
     f.close()
 

--- a/src/ddt4all/ui/main_window/main_widget.py
+++ b/src/ddt4all/ui/main_window/main_widget.py
@@ -63,8 +63,7 @@ class MainWidget(widgets.QMainWindow):
         super(MainWidget, self).__init__(parent)
         self.setIcon()
         if not options.simulation_mode:
-            if not os.path.exists(get_logs_dir()):
-                os.mkdir(get_logs_dir())
+            Path(get_logs_dir()).mkdir(parents=True, exist_ok=True)
             self.screenlogfile = open(os.path.join(get_logs_dir() / "screens.txt"), "at", encoding="utf-8")
         else:
             self.screenlogfile = None


### PR DESCRIPTION
Une PR pour que tu ais une version appimage du programme. Ça sera plus simple pour tes users linux.

Ça semble ok, mais je t'invite quand même à vérifier que ça continue à bien fonctionner. J'ai du modifier la gestion des chemins des fichiers de config, logs, ecu, etc.


### Résumé

Migration vers des chemins plateforme standard avec `platformdirs`, ajout d'un build
AppImage reproductible (local + CI).

### Modifications

**`src/ddt4all/file_manager.py`**
- Ajout de `platformdirs` pour résoudre les chemins selon le système d'exploitation
- Nouvelle fonction `get_projects_path()` : priorité au `projects.json` utilisateur
  dans `~/.local/share/ddt4all/`, fallback celui packagé dans l'application
- `get_logs_dir()` redirigé vers `user_log_dir` (`~/.local/state/ddt4all/log/`)
  en mode plateforme
- Détection legacy étendue à `ecus/eculist.xml`

**`src/ddt4all/main.py`**
- `load_this()` utilise `get_projects_path()` au lieu du chemin bundle fixe
- `os.mkdir` → `Path.mkdir(parents=True, exist_ok=True)`

**`src/ddt4all/options.py`**
- `save_config()` crée le dossier parent avant d'écrire `config.json`

**`src/ddt4all/core/elm/elm.py`** / **`src/ddt4all/ui/main_window/main_widget.py`**
- `os.mkdir(get_logs_dir())` → `Path.mkdir(parents=True, exist_ok=True)`

**`pyproject.toml`**
- Ajout de `platformdirs>=3.0.0,<4.0`

**Nouveaux fichiers**
- `setup_tools/appimage/build.sh` — script de build AppImage (détection Python,
  bundle Qt5, création AppImage)
- `.github/workflows/build-appimage.yml` — workflow CI déclenché sur tag `v*`,
  build + upload vers la release

### Chemins par plateforme

| Type | Linux | Windows | macOS |
|------|-------|---------|-------|
| Config | `~/.config/ddt4all/` | `%APPDATA%\ddt4all\` | `~/Library/Application Support/ddt4all/` |
| Données | `~/.local/share/ddt4all/` | `%APPDATA%\ddt4all\` | `~/Library/Application Support/ddt4all/` |
| Logs | `~/.local/state/ddt4all/log/` | `%APPDATA%\ddt4all\log\` | `~/Library/Logs/ddt4all/` |

Rétrocompatibilité : si `config.json`, `json/` ou `ecus/eculist.xml` existent dans
le CWD, le comportement historique est conservé.

### Build AppImage

```bash
# Local
. .venv/bin/activate
bash setup_tools/appimage/build.sh "v3.2.0"
# → ddt4all-v3.2.0-x86_64.AppImage

# CI : pousser un tag
git tag v3.2.0 && git push origin v3.2.0
# Le workflow build + attache l'AppImage à la release