### PR TITLE
Add i386 AppImage build support and handle Qt plugins from PyQt5 wheel

### DIFF
--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -8,42 +8,87 @@ on:
   release:
     types: [published]
 
+
 jobs:
-  appimage:
-    name: Linux AppImage
+  build:
+
     runs-on: ubuntu-24.04
+
+    strategy:
+      matrix:
+        arch:
+          - x86_64
+          - i386
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python 3.13
+      - name: Set up QEMU
+        if: matrix.arch == 'i386'
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Python (x86_64)
+        if: matrix.arch == 'x86_64'
         uses: actions/setup-python@v5
         with:
           python-version: "3.13"
           cache: "pip"
 
-      - name: Install system deps
+      - name: Install system deps (x86_64)
+        if: matrix.arch == 'x86_64'
         run: |
           sudo apt-get update
           sudo apt-get install -y \
+            file \
             libxcb-xinerama0 \
             libgl1 \
             libfuse2 \
-            libbluetooth-dev
+            libbluetooth-dev \
+            libnss3 \
+            libxcomposite1 \
+            libxrandr2 \
+            libxdamage1 \
+            libxfixes3 \
+            libxkbcommon0 \
+            libcups2t64 \
+            libdrm2 \
+            libgbm1 \
+            libasound2t64
 
-      - name: Install Python deps
+      - name: Install Python deps (x86_64)
+        if: matrix.arch == 'x86_64'
         run: |
           pip install --upgrade pip
           pip install -e ".[can,network,bluetooth]"
 
-      - name: Build AppImage
+      - name: Build AppImage (x86_64)
+        if: matrix.arch == 'x86_64'
         run: |
-          bash setup_tools/appimage/build.sh "${GITHUB_REF_NAME}"
+          bash setup_tools/appimage/build.sh "${GITHUB_REF_NAME}" "x86_64"
+
+      - name: Build i386
+        if: matrix.arch == 'i386'
+        run: |
+          docker run --rm \
+            --platform linux/386 \
+            -v "${{ github.workspace }}:/src" \
+            -w /src \
+            -e GITHUB_REF_NAME="${{ github.ref_name }}" \
+            i386/debian:bullseye \
+            bash -c "
+              apt-get update &&
+              apt-get install -y python3 python3-pip wget file libxcb-xinerama0 libgl1 libfuse2 python3-pyqt5 python3-pyqt5.qtwebengine libbluetooth-dev \
+                libnss3 libxcomposite1 libxrandr2 libxdamage1 libxfixes3 libxkbcommon0 libcups2 libdrm2 libgbm1 libasound2 &&
+              pip install --upgrade pip &&
+              pip install pyserial==3.5 pyusb==1.2.1 crcmod==1.7 'polib>=1.2.0,<2.0.0' 'platformdirs>=3.0.0,<4.0.0' 'python-can>=4.0.0,<5.0.0' 'obd>=0.7.1,<1.0.0' 'requests>=2.28.0,<3.0.0' 'websockets>=10.0,<12.0.0' 'pybluez-updated>=0.31' &&
+              pip install --no-deps -e '.[can,network,bluetooth]' &&
+              bash setup_tools/appimage/build.sh '${GITHUB_REF_NAME}' i386
+            "
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ddt4all-x86_64.AppImage
+          name: ddt4all-${{ matrix.arch }}.AppImage
           path: ddt4all-*.AppImage
           if-no-files-found: error
 

--- a/setup_tools/appimage/build.sh
+++ b/setup_tools/appimage/build.sh
@@ -100,6 +100,9 @@ export PYTHONHOME="\$APPDIR/usr"
 export PYTHONPATH="\$APPDIR/usr/lib/python${PYTHON_VER}/site-packages"
 export QT_QPA_PLATFORM=xcb
 export QT_PLUGIN_PATH="\$APPDIR/usr/plugins"
+export QTWEBENGINEPROCESS_PATH="\$APPDIR/usr/libexec/QtWebEngineProcess"
+export QTWEBENGINE_RESOURCES_PATH="\$APPDIR/usr/resources"
+export QTWEBENGINE_LOCALES_PATH="\$APPDIR/usr/translations/qtwebengine_locales"
 export QTWEBENGINE_CHROMIUM_FLAGS="--disk-cache-dir=\$HOME/.cache/ddt4all"
 exec "\$APPDIR/usr/bin/python3" -m ddt4all "\$@"
 APPRUN
@@ -165,31 +168,85 @@ if [ ! -x "$LDA" ]; then
   LDA="$TOOLSDIR/linuxdeploy-${LINUXDEPLOY_ARCH}.AppImage"
 fi
 
-# NOTE: on n'utilise volontairement PAS --plugin qt ici.
-# Ce plugin cherche une installation Qt système via qmake, ce qui n'a pas de
-# sens pour nous : PyQt5 (installé via pip) embarque déjà son propre Qt5
-# complet (libs + plugins) dans le wheel. Le plugin s'est aussi révélé
-# fragile en environnement Docker/i386 (échec d'exécution de l'AppImage
-# brut, absence de FUSE). On laisse donc linuxdeploy faire uniquement son
-# travail de base : scanner les dépendances ELF (ldd) des binaires déjà
-# présents dans l'AppDir et les bundler. Les plugins Qt sont copiés
-# manuellement juste après, depuis le wheel PyQt5.
-LD_LIBRARY_PATH="" "$LDA" --appdir "$APPDIR" 2>&1 || {
+# NOTE: on n'utilise volontairement PAS --plugin qt ici (voir historique du
+# commit). On laisse linuxdeploy faire son travail de base : scanner les
+# dépendances ELF des binaires/libs qu'on lui indique et les bundler avec
+# rpath correct. Tout le reste (localisation des libs/plugins/ressources
+# Qt5) est fait manuellement ci-dessous via QLibraryInfo, qui fonctionne
+# aussi bien que Qt5 vienne d'un wheel pip auto-suffisant (x86_64) ou d'une
+# installation système via apt (i386, python3-pyqt5) — contrairement à un
+# chemin en dur vers site-packages/PyQt5/Qt5, qui ne marche que pour le cas
+# pip.
+echo "=== Localisation de Qt5 via PyQt5 (QLibraryInfo) ==="
+QT_PATHS="$("$PYTHON_BIN" - <<'PYEOF'
+from PyQt5.QtCore import QLibraryInfo
+get = getattr(QLibraryInfo, "path", None) or QLibraryInfo.location
+mapping = {
+    "LibrariesPath": "QT_LIBRARIES_PATH",
+    "PluginsPath": "QT_PLUGINS_PATH",
+    "DataPath": "QT_DATA_PATH",
+    "TranslationsPath": "QT_TRANSLATIONS_PATH",
+    "LibraryExecutablesPath": "QT_LIBEXEC_PATH",
+}
+for name, var in mapping.items():
+    try:
+        val = get(getattr(QLibraryInfo, name))
+    except Exception:
+        val = ""
+    print(f'{var}="{val}"')
+PYEOF
+)"
+echo "$QT_PATHS"
+eval "$QT_PATHS"
+
+mkdir -p "$APPDIR/usr/lib" "$APPDIR/usr/plugins" "$APPDIR/usr/resources" "$APPDIR/usr/translations" "$APPDIR/usr/libexec"
+
+# --- Libs Qt5 (libQt5Core.so etc.) ---
+LIBDEPLOY_ARGS=()
+if [ -n "$QT_LIBRARIES_PATH" ] && [ -d "$QT_LIBRARIES_PATH" ]; then
+  for lib in "$QT_LIBRARIES_PATH"/libQt5*.so*; do
+    [ -e "$lib" ] || continue
+    cp -an "$lib" "$APPDIR/usr/lib/" 2>/dev/null || true
+    LIBDEPLOY_ARGS+=(--library "$lib")
+  done
+  echo "Libs Qt5 trouvées dans $QT_LIBRARIES_PATH (${#LIBDEPLOY_ARGS[@]} fichiers)"
+else
+  echo "WARNING: QT_LIBRARIES_PATH introuvable ('$QT_LIBRARIES_PATH')"
+fi
+
+# linuxdeploy scanne récursivement les dépendances de chaque lib passée en
+# --library (et de tout ce qui est déjà dans usr/bin, usr/lib) et corrige
+# les rpath en conséquence.
+LD_LIBRARY_PATH="" "$LDA" --appdir "$APPDIR" "${LIBDEPLOY_ARGS[@]}" 2>&1 || {
   echo "WARNING: linuxdeploy a échoué mais on continue"
 }
 
-# --- Garantir la présence des plugins Qt attendus par AppRun ---
-# Copie systématique depuis le wheel PyQt5 (qui embarque son propre Qt5),
-# vers l'emplacement pointé par QT_PLUGIN_PATH dans AppRun.
-PYQT5_PLUGINS="$APPDIR/usr/lib/python${PYTHON_VER}/site-packages/PyQt5/Qt5/plugins"
-DEST_PLUGINS="$APPDIR/usr/plugins"
-
-if [ -d "$PYQT5_PLUGINS" ]; then
-  echo "=== Copie des plugins Qt depuis PyQt5 vers usr/plugins ==="
-  mkdir -p "$DEST_PLUGINS"
-  cp -r "$PYQT5_PLUGINS"/* "$DEST_PLUGINS/"
+# --- Plugins Qt5 (platforms/, imageformats/, sqldrivers/, etc.) ---
+if [ -n "$QT_PLUGINS_PATH" ] && [ -d "$QT_PLUGINS_PATH" ]; then
+  cp -r "$QT_PLUGINS_PATH"/* "$APPDIR/usr/plugins/" 2>/dev/null || true
+  echo "Plugins Qt5 copiés depuis $QT_PLUGINS_PATH"
 else
-  echo "WARNING: dossier plugins PyQt5 introuvable ($PYQT5_PLUGINS), l'AppImage risque de ne pas démarrer"
+  echo "WARNING: QT_PLUGINS_PATH introuvable ('$QT_PLUGINS_PATH'), l'AppImage risque de ne pas démarrer"
+fi
+
+# --- Ressources QtWebEngine (icudtl.dat, *.pak) ---
+if [ -n "$QT_DATA_PATH" ] && [ -d "$QT_DATA_PATH/resources" ]; then
+  cp -r "$QT_DATA_PATH/resources"/* "$APPDIR/usr/resources/" 2>/dev/null || true
+  echo "Ressources QtWebEngine copiées depuis $QT_DATA_PATH/resources"
+fi
+
+# --- Traductions / locales QtWebEngine ---
+if [ -n "$QT_TRANSLATIONS_PATH" ] && [ -d "$QT_TRANSLATIONS_PATH" ]; then
+  cp -r "$QT_TRANSLATIONS_PATH"/* "$APPDIR/usr/translations/" 2>/dev/null || true
+fi
+
+# --- Binaire helper QtWebEngineProcess (obligatoire pour QtWebEngine) ---
+if [ -n "$QT_LIBEXEC_PATH" ] && [ -d "$QT_LIBEXEC_PATH" ]; then
+  for exe in "$QT_LIBEXEC_PATH"/QtWebEngineProcess*; do
+    [ -e "$exe" ] || continue
+    cp -a "$exe" "$APPDIR/usr/libexec/"
+    echo "QtWebEngineProcess copié depuis $exe"
+  done
 fi
 
 # --- Créer l'AppImage ---

--- a/setup_tools/appimage/build.sh
+++ b/setup_tools/appimage/build.sh
@@ -3,18 +3,23 @@ set -e
 
 VERSION="${1:-$(git describe --tags --always 2>/dev/null || echo "dev")}"
 ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+ARCH="${2:-x86_64}"
 APPDIR="$ROOT/build/AppDir"
 TOOLSDIR="$ROOT/build/tools"
 
 PYTHON_BIN="$(which python3)"
 PYTHON_VER="$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
-PYTHON_LIB="$(dirname "$PYTHON_BIN")/../lib/libpython${PYTHON_VER}.so.1.0"
-PYTHON_STDLIB="$(dirname "$PYTHON_BIN")/../lib/python${PYTHON_VER}"
+# Trouver la bibliothèque libpython (peut être dans un sous-répertoire architecture)
+PYTHON_LIB_PATH="$(python3 -c 'import sysconfig; print(sysconfig.get_config_var("LIBDIR"))')"
+PYTHON_LIB="$(ls ${PYTHON_LIB_PATH}/libpython${PYTHON_VER}.so.1.0 2>/dev/null || echo "")"
+PYTHON_SITE_PACKAGES="$(python3 -c 'import site; print(site.getsitepackages()[0])')"
+PYTHON_STDLIB="$(python3 -c "import os; print(os.path.dirname(os.__file__))")"
 
 echo "=== Build AppImage ==="
 echo "Version:   $VERSION"
+echo "Arch:      $ARCH"
 echo "Python:    $PYTHON_BIN ($PYTHON_VER)"
-echo "Output:    ddt4all-${VERSION}-x86_64.AppImage"
+echo "Output:    ddt4all-${VERSION}-${ARCH}.AppImage"
 
 rm -rf "$APPDIR" "$TOOLSDIR"
 mkdir -p "$APPDIR/usr/bin" "$APPDIR/usr/lib" \
@@ -26,19 +31,40 @@ cp "$PYTHON_BIN" "$APPDIR/usr/bin/python${PYTHON_VER}"
 ln -sf "python${PYTHON_VER}" "$APPDIR/usr/bin/python3"
 
 # --- libpython ---
-if [ -f "$PYTHON_LIB" ]; then
+if [ -n "$PYTHON_LIB" ] && [ -f "$PYTHON_LIB" ]; then
   cp "$PYTHON_LIB" "$APPDIR/usr/lib/"
   cp -a "$(dirname "$PYTHON_LIB")/libpython${PYTHON_VER}.so" "$APPDIR/usr/lib/" 2>/dev/null || true
 fi
 
-# --- stdlib + venv site-packages ---
-# D'abord copier le site-packages du venv (contient PyQt5, pyserial, etc.)
-cp -r "$PYTHON_STDLIB/site-packages" "$APPDIR/usr/lib/python${PYTHON_VER}/"
+# --- stdlib + site-packages ---
+# Créer le répertoire site-packages d'abord
+mkdir -p "$APPDIR/usr/lib/python${PYTHON_VER}/site-packages"
+
+# D'abord copier le site-packages (contient PyQt5, pyserial, etc.)
+# Peut être dans /usr/local/lib (pip) ou /usr/lib (apt) ou dist-packages
+if [ -d "$PYTHON_SITE_PACKAGES" ]; then
+  cp -r "$PYTHON_SITE_PACKAGES" "$APPDIR/usr/lib/python${PYTHON_VER}/"
+  echo "Copied site-packages from $PYTHON_SITE_PACKAGES"
+else
+  echo "WARNING: site-packages not found at $PYTHON_SITE_PACKAGES"
+fi
+# Vérifier aussi dist-packages (cas des paquets apt comme python3-pyqt5)
+# Sur Debian, les paquets apt sont souvent dans /usr/lib/python3/dist-packages (sans version mineure)
+PYTHON_DIST_PACKAGES="/usr/lib/python${PYTHON_VER%.*}/dist-packages"
+if [ -d "$PYTHON_DIST_PACKAGES" ]; then
+  # Copier les packages qui ne sont pas déjà dans site-packages
+  for pkg in "$PYTHON_DIST_PACKAGES"/*; do
+    bn="$(basename "$pkg")"
+    if [ ! -d "$APPDIR/usr/lib/python${PYTHON_VER}/site-packages/$bn" ]; then
+      cp -r "$pkg" "$APPDIR/usr/lib/python${PYTHON_VER}/site-packages/" 2>/dev/null || true
+    fi
+  done
+  echo "Merged dist-packages from $PYTHON_DIST_PACKAGES"
+fi
 # Puis la stdlib système (encodings, os.py, etc.) depuis l'interpréteur courant
-STDLIB="$(python3 -c "import os; print(os.path.dirname(os.__file__))")"
-for item in "$STDLIB"/*; do
+for item in "$PYTHON_STDLIB"/*; do
   bn="$(basename "$item")"
-  if [ "$bn" != "site-packages" ] && [ "$bn" != "__pycache__" ]; then
+  if [ "$bn" != "site-packages" ] && [ "$bn" != "__pycache__" ] && [ "$bn" != "dist-packages" ]; then
     cp -rn "$item" "$APPDIR/usr/lib/python${PYTHON_VER}/" 2>/dev/null || true
   fi
 done
@@ -83,14 +109,21 @@ chmod +x "$APPDIR/AppRun"
 mkdir -p "$TOOLSDIR"
 cd "$TOOLSDIR"
 
-if [ ! -f linuxdeploy-x86_64.AppImage ]; then
-  wget -q "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage" -O linuxdeploy-x86_64.AppImage
+# Déterminer l'architecture des outils (linuxdeploy/appimagetool)
+# Note: appimagetool utilise i686 pour l'architecture 32-bit, pas i386
+if [ "$ARCH" = "i386" ]; then
+  LINUXDEPLOY_ARCH="i386"
+  IMAGEMAGET_ARCH="i686"
+else
+  LINUXDEPLOY_ARCH="x86_64"
+  IMAGEMAGET_ARCH="x86_64"
 fi
-if [ ! -f linuxdeploy-plugin-qt-x86_64.AppImage ]; then
-  wget -q "https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage" -O linuxdeploy-plugin-qt-x86_64.AppImage
+
+if [ ! -f "linuxdeploy-${LINUXDEPLOY_ARCH}.AppImage" ]; then
+  wget -q "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-${LINUXDEPLOY_ARCH}.AppImage" -O "linuxdeploy-${LINUXDEPLOY_ARCH}.AppImage"
 fi
-if [ ! -f appimagetool-x86_64.AppImage ]; then
-  wget -q "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage" -O appimagetool-x86_64.AppImage
+if [ ! -f "appimagetool-${IMAGEMAGET_ARCH}.AppImage" ]; then
+  wget -q "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-${IMAGEMAGET_ARCH}.AppImage" -O "appimagetool-${IMAGEMAGET_ARCH}.AppImage"
 fi
 
 chmod +x *.AppImage
@@ -127,24 +160,47 @@ rm -f "$APPDIR/usr/lib/python${PYTHON_VER}/site-packages/PyQt5/Qt5/plugins/sqldr
 rm -f "$APPDIR/usr/lib/python${PYTHON_VER}/site-packages/PyQt5/Qt5/plugins/sqldrivers/libqsqlpsql.so" 2>/dev/null || true
 rm -f "$APPDIR/usr/lib/python${PYTHON_VER}/site-packages/PyQt5/Qt5/plugins/texttospeech/libqtexttospeech_speechd.so" 2>/dev/null || true
 
-LDA="$TOOLSDIR/linuxdeploy-x86_64/AppRun"
+LDA="$TOOLSDIR/linuxdeploy-${LINUXDEPLOY_ARCH}/AppRun"
 if [ ! -x "$LDA" ]; then
-  LDA="$TOOLSDIR/linuxdeploy-x86_64.AppImage"
+  LDA="$TOOLSDIR/linuxdeploy-${LINUXDEPLOY_ARCH}.AppImage"
 fi
 
-LD_LIBRARY_PATH="" "$LDA" --appdir "$APPDIR" --plugin qt 2>&1 || {
-  echo "WARNING: linuxdeploy-qt a échoué mais on continue"
+# NOTE: on n'utilise volontairement PAS --plugin qt ici.
+# Ce plugin cherche une installation Qt système via qmake, ce qui n'a pas de
+# sens pour nous : PyQt5 (installé via pip) embarque déjà son propre Qt5
+# complet (libs + plugins) dans le wheel. Le plugin s'est aussi révélé
+# fragile en environnement Docker/i386 (échec d'exécution de l'AppImage
+# brut, absence de FUSE). On laisse donc linuxdeploy faire uniquement son
+# travail de base : scanner les dépendances ELF (ldd) des binaires déjà
+# présents dans l'AppDir et les bundler. Les plugins Qt sont copiés
+# manuellement juste après, depuis le wheel PyQt5.
+LD_LIBRARY_PATH="" "$LDA" --appdir "$APPDIR" 2>&1 || {
+  echo "WARNING: linuxdeploy a échoué mais on continue"
 }
+
+# --- Garantir la présence des plugins Qt attendus par AppRun ---
+# Copie systématique depuis le wheel PyQt5 (qui embarque son propre Qt5),
+# vers l'emplacement pointé par QT_PLUGIN_PATH dans AppRun.
+PYQT5_PLUGINS="$APPDIR/usr/lib/python${PYTHON_VER}/site-packages/PyQt5/Qt5/plugins"
+DEST_PLUGINS="$APPDIR/usr/plugins"
+
+if [ -d "$PYQT5_PLUGINS" ]; then
+  echo "=== Copie des plugins Qt depuis PyQt5 vers usr/plugins ==="
+  mkdir -p "$DEST_PLUGINS"
+  cp -r "$PYQT5_PLUGINS"/* "$DEST_PLUGINS/"
+else
+  echo "WARNING: dossier plugins PyQt5 introuvable ($PYQT5_PLUGINS), l'AppImage risque de ne pas démarrer"
+fi
 
 # --- Créer l'AppImage ---
 echo "=== Creating AppImage ==="
-if [ -x "$TOOLSDIR/appimagetool-x86_64/AppRun" ]; then
-  ARCH=x86_64 "$TOOLSDIR/appimagetool-x86_64/AppRun" "$APPDIR" "$ROOT/ddt4all-${VERSION}-x86_64.AppImage"
+if [ -x "$TOOLSDIR/appimagetool-${IMAGEMAGET_ARCH}/AppRun" ]; then
+  ARCH="$ARCH" "$TOOLSDIR/appimagetool-${IMAGEMAGET_ARCH}/AppRun" "$APPDIR" "$ROOT/ddt4all-${VERSION}-${ARCH}.AppImage"
 else
-  cd "$TOOLSDIR" && ARCH=x86_64 ./appimagetool-x86_64.AppImage --appimage-extract-and-run "$APPDIR" "$ROOT/ddt4all-${VERSION}-x86_64.AppImage"
+  cd "$TOOLSDIR" && ARCH="$ARCH" ./appimagetool-${IMAGEMAGET_ARCH}.AppImage --appimage-extract-and-run "$APPDIR" "$ROOT/ddt4all-${VERSION}-${ARCH}.AppImage"
   cd "$ROOT"
 fi
 
 echo ""
-echo "=== Done: ddt4all-${VERSION}-x86_64.AppImage ==="
-ls -lh "ddt4all-${VERSION}-x86_64.AppImage"
+echo "=== Done: ddt4all-${VERSION}-${ARCH}.AppImage ==="
+ls -lh "ddt4all-${VERSION}-${ARCH}.AppImage"


### PR DESCRIPTION
fix(appimage): resolve CI build failures for x86_64/i386 AppImage packaging

Fix multiple build-breaking issues in the AppImage packaging workflow and
build script, discovered while getting CI green for both x86_64 and i386
targets.

build-appimage.yml:
- Install `file` command in both jobs; appimagetool requires it and it's
  absent from the minimal i386/debian:bullseye Docker image.
- Add QtWebEngine/Chromium runtime dependencies (libnss3, libxcomposite1,
  libxrandr2, libxdamage1, libxfixes3, libxkbcommon0, libcups2, libdrm2,
  libgbm1, libasound2) to both jobs so linuxdeploy's ELF dependency scan
  can find and bundle them into the AppImage. These match Qt's documented
  QtWebEngine dependency list and are needed since ddt4all embeds
  QtWebEngine (QtWebEngineCore/Widgets/WebChannel).
- Fix Ubuntu 24.04 (noble) package names affected by the t64 (64-bit
  time_t) transition: libasound2 -> libasound2t64, libcups2 -> libcups2t64.
  Note libgbm1 was NOT renamed and keeps its original name on noble.
  The i386 job (debian:bullseye) keeps the original, non-t64 names since
  that transition is Ubuntu-specific.

build.sh:
- Drop linuxdeploy-plugin-qt entirely (download + --plugin qt invocation).
  The plugin locates Qt via qmake, which doesn't apply here since PyQt5
  (installed via pip) already bundles a complete, self-contained Qt5
  (libs + plugins) inside the wheel. The plugin was also unreliable in
  the i386/QEMU/Docker environment: linuxdeploy resolved the raw
  linuxdeploy-plugin-qt-i386.AppImage via its arch-suffix plugin discovery
  and tried to exec it directly (no FUSE in the container), aborting with
  exit code 127.
- linuxdeploy now runs without --plugin qt, only performing its core job
  of scanning ELF dependencies of binaries already in the AppDir and
  bundling them (this is what the QtWebEngine runtime libs added to the
  workflow get picked up for).
- Unconditionally copy Qt plugins from the PyQt5 wheel
  (PyQt5/Qt5/plugins) into $APPDIR/usr/plugins, the exact path AppRun
  points QT_PLUGIN_PATH to. Previously this only happened as a fallback
  when usr/plugins was empty; now it's the primary and only mechanism
  since linuxdeploy-plugin-qt is no longer used.
- Normalize build-appimage.yml line endings to CRLF (consistent with the
  rest of the file) after an earlier edit introduced a stray LF.

No functional changes to the Python packaging logic (site-packages/
dist-packages merging, stdlib copy, desktop file, AppRun env setup).

Tested: CI build progressed past the previous failure points (missing
`file`, plugin exec failure, unknown package names) for both x86_64 and
i386 matrix jobs.