### PR TITLE
Update elm.py

### DIFF
--- a/src/ddt4all/core/elm/elm.py
+++ b/src/ddt4all/core/elm/elm.py
@@ -502,8 +502,10 @@ class ELM:
                 res_version = res_version.replace(">", " ").replace("STI", " ").strip()
                 stn_detected = re.search(r"\bSTN\d+\b", res_version, re.IGNORECASE) is not None
 
-            if stn_detected:
-                options.opt_stn_basic = True
+            if stn_detected:# check STN
+                elm_stp_53 = self.cmd("STP 53")
+                if '?' not in elm_stp_53:
+                   options.opt_stn_basic = True
                 print(_("STN connection established"))
                 print(_("Version: ") + res_version)
                 odblink_meta = res_version.split()

--- a/src/ddt4all/core/elm/elm.py
+++ b/src/ddt4all/core/elm/elm.py
@@ -506,7 +506,7 @@ class ELM:
                 # check STN
                 elm_stp_53 = self.cmd("STP 53")
                 if '?' not in elm_stp_53:
-                   options.opt_stn_basic = True
+                    options.opt_stn_basic = True
                 print(_("STN connection established"))
                 print(_("Version: ") + res_version)
                 odblink_meta = res_version.split()

--- a/src/ddt4all/core/elm/elm.py
+++ b/src/ddt4all/core/elm/elm.py
@@ -502,7 +502,8 @@ class ELM:
                 res_version = res_version.replace(">", " ").replace("STI", " ").strip()
                 stn_detected = re.search(r"\bSTN\d+\b", res_version, re.IGNORECASE) is not None
 
-            if stn_detected:# check STN
+            if stn_detected:
+                # check STN
                 elm_stp_53 = self.cmd("STP 53")
                 if '?' not in elm_stp_53:
                    options.opt_stn_basic = True

--- a/src/ddt4all/core/elm/elm.py
+++ b/src/ddt4all/core/elm/elm.py
@@ -422,6 +422,9 @@ class ELM:
         self.adapter_type = adapter_type
         options.port_speed = rate
         self.stpx_enabled = False  # Initialize STPX mode flag
+        # PIC cable: never inherit STN capabilities from an earlier adapter.
+        options.opt_stn_basic = False
+        options.opt_stpx_full = False
         # Build speed list: user's chosen rate first, then common fallbacks.
         # dict.fromkeys preserves order and removes duplicates (e.g. when rate == 38400).
         _speed_candidates = list(dict.fromkeys([int(rate), 38400, 115200, 230400, 57600, 9600, 500000, 1000000, 2000000]))
@@ -477,39 +480,53 @@ class ELM:
                 self.__del__()
                 continue
 
-            # check OBDLink
-            elm_rsp = self.cmd("STI")
+            # PIC_ELM_ATI_DETECTION_FIX: identify generic ELM adapters with ATI, not only ATZ.
+            # Some PIC18F25K80 firmware echoes ATZ without returning its banner.
+            previous_probe_timeout = self.portTimeout
+            try:
+                self.portTimeout = 2.0 if speed == int(rate) else 0.75
+                ati_rsp = self.send_raw("ATI")
+                identity = (clean_bytestring(res) + "\n" + clean_bytestring(ati_rsp)).upper()
+                if "ELM" not in identity and "OBDII" not in identity:
+                    at1_rsp = self.send_raw("AT@1")
+                    identity += "\n" + clean_bytestring(at1_rsp).upper()
+            finally:
+                self.portTimeout = previous_probe_timeout
 
-            # Verify STN response
-            res_version = elm_rsp.replace("\n", "").replace(">", "").replace("STI", "")
-            stn_detected = "STN" in res_version.upper()
-            elm_detected = "ELM" in res.upper() or "OBDII" in res.upper()
-            if "STN" in res_version:
+            elm_detected = "ELM" in identity or "OBDII" in identity
+            stn_detected = False
+            res_version = ""
+
+            # STI and STP are STN extensions. Do not probe them on STD_USB PIC cables.
+            stn_adapter_types = {"OBDLINK", "OBDLINK_EX", "VLINKER", "VGATE", "STN"}
+            if elm_detected and str(adapter_type).upper() in stn_adapter_types:
+                elm_rsp = self.cmd("STI")
+                res_version = clean_bytestring(elm_rsp).replace("\r", "").replace("\n", " ")
+                res_version = res_version.replace(">", " ").replace("STI", " ").strip()
+                stn_detected = re.search(r"\bSTN\d+\b", res_version, re.IGNORECASE) is not None
+
+            if stn_detected:
+                options.opt_stn_basic = True
                 print(_("STN connection established"))
                 print(_("Version: ") + res_version)
-            if elm_rsp and '?' not in elm_rsp and len(elm_rsp.split(" ")) == 2:
-                odblink_meta = elm_rsp.split(" ")
-                ic_type = odblink_meta[0]
-                firmware_version = odblink_meta[1]
+                odblink_meta = res_version.split()
+                if len(odblink_meta) >= 2:
+                    ic_type = odblink_meta[0]
+                    firmware_version = odblink_meta[1]
 
-                if ic_type.startswith("STN1"):
-                    options.elm_uart_buffer_size = 0x1ff
-                elif ic_type.startswith("STN2"):
-                    options.elm_uart_buffer_size = 0x3ff
+                    if ic_type.startswith("STN1"):
+                        options.elm_uart_buffer_size = 0x1ff
+                    elif ic_type.startswith("STN2"):
+                        options.elm_uart_buffer_size = 0x3ff
 
-                try:
-                    firmware_version = firmware_version.split(".")
-                    version_number = int(''.join([re.sub(r'\D', '', version) for version in firmware_version]))
-                    stpx_introduced_in_version_number = 420  # STN1110 got STPX last in version v4.2.0
-                    if version_number >= stpx_introduced_in_version_number:
-                        options.opt_stpx_full = True
-                except Exception as e:
-                    print(_("STPX/STN configuration warning: %s") % e)
-
-                # check STN
-                elm_rsp = self.cmd("STP 53")
-                if '?' not in elm_rsp:
-                    options.opt_stn_basic = True
+                    try:
+                        version_parts = firmware_version.split(".")
+                        version_number = int("".join(re.sub(r"\D", "", part) for part in version_parts))
+                                                                                                      
+                        if version_number >= 420:
+                            options.opt_stpx_full = True
+                    except Exception as e:
+                        print(_("STPX/STN configuration warning: %s") % e)
 
             if elm_detected or stn_detected:
                 options.last_error = ""

--- a/src/ddt4all/core/elm/elm.py
+++ b/src/ddt4all/core/elm/elm.py
@@ -422,9 +422,6 @@ class ELM:
         self.adapter_type = adapter_type
         options.port_speed = rate
         self.stpx_enabled = False  # Initialize STPX mode flag
-        # PIC cable: never inherit STN capabilities from an earlier adapter.
-        options.opt_stn_basic = False
-        options.opt_stpx_full = False
         # Build speed list: user's chosen rate first, then common fallbacks.
         # dict.fromkeys preserves order and removes duplicates (e.g. when rate == 38400).
         _speed_candidates = list(dict.fromkeys([int(rate), 38400, 115200, 230400, 57600, 9600, 500000, 1000000, 2000000]))


### PR DESCRIPTION
This change is to fix some USB Elm327 v1.4 with FTDI and PIC18F25K80 cables.

Some ELM327 cables do not use ATZ command to identify themselves, instead they use ATI command or AT@1.

Due to the PIC18F25K80 they also only reply using 500k baudrate and do not like being probed for Auto switching between CAN1 and CAN2, and doing so, causes CAN1 to return no data.

This is what the cable reports:

=== Starting FTDI/PIC Cable Diagnostic on COM1 ===

[+] Opening port at 500000 baud...
  --> Sending: ATZ\r
  <-- Raw Hex:  41 54 5a 0d
  <-- Response: 'ATZ'
  --> Sending: ATE0\r
  <-- Response: [NO REPLY / TIMEOUT]
  --> Sending: ATI\r
  <-- Raw Hex:  0d 0d 45 4c 4d 33 32 37 20 76 31 2e 34 0d 0d 3e
  <-- Response: 'ELM327 v1.4\r\r>'
  --> Sending: AT@1\r
  <-- Raw Hex:  41 54 40 31 0d 4f 42 44 49 49 20 74 6f 20 52 53 32 33 32 20 49 6e 74 65 72 70 72 65 74 65 72 0d 0d 3e
  <-- Response: 'AT@1\rOBDII to RS232 Interpreter\r\r>'
  --> Sending: ATDP\r
  <-- Raw Hex:  41 54 44 50 0d 49 53 4f 20 31 34 32 33 30 2d 34 20 28 4b 57 50 20 35 42 41 55 44 29 0d 0d 3e
  <-- Response: 'ATDP\rISO 14230-4 (KWP 5BAUD)\r\r>'
[+] Closed port at 500000 baud.

[+] Opening port at 115200 baud...
  --> Sending: ATZ\r
  <-- Raw Hex:  ff
  <-- Response: ' '
  --> Sending: ATE0\r
  <-- Raw Hex:  fe
  <-- Response: ' '
  --> Sending: ATI\r
  <-- Raw Hex:  78
  <-- Response: 'x'
  --> Sending: AT@1\r
  <-- Raw Hex:  fe
  <-- Response: ' '
  --> Sending: ATDP\r
  <-- Raw Hex:  ff
  <-- Response: ' '
[+] Closed port at 115200 baud.

[+] Opening port at 38400 baud...
  --> Sending: ATZ\r
  <-- Response: [NO REPLY / TIMEOUT]
  --> Sending: ATE0\r
  <-- Response: [NO REPLY / TIMEOUT]
  --> Sending: ATI\r
  <-- Response: [NO REPLY / TIMEOUT]
  --> Sending: AT@1\r
  <-- Response: [NO REPLY / TIMEOUT]
  --> Sending: ATDP\r
  <-- Response: [NO REPLY / TIMEOUT]
[+] Closed port at 38400 baud.

The fix has been tested with the cable I have and it works with both CAN1 and CAN2 (manual toggle switch) returning valid data on both lines.

Hopefully this fix can be applied so it is included in any future updates for all users of these types of ELM327 cables.

I have tried to implement this fix in such a way that it does not break any existing code or cable detection, but I can not confirm that as I do not have all the other cable types.